### PR TITLE
Add option to allow filtering of long segments

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,7 @@ Improvements
 - A heuristic trick is added to prevent serious V/UV prediction errors . `#95`_ `#119`_
 - Speech parameter trajectory smoothing (:cite:t:`takamichi2015naist`). Disabled by default.
 - Added recipe tests on CI `#116`_
+- Add option to allow filtering of long segments `#135`_
 
 Deprecations
 ^^^^^^^^^^^^
@@ -101,4 +102,5 @@ PyPi release is also available. So you can install the core library by pip insta
 .. _#125: https://github.com/r9y9/nnsvs/pull/125
 .. _#128: https://github.com/r9y9/nnsvs/pull/128
 .. _#129: https://github.com/r9y9/nnsvs/pull/129
+.. _#135: https://github.com/r9y9/nnsvs/pull/135
 

--- a/docs/update_guide.rst
+++ b/docs/update_guide.rst
@@ -66,6 +66,8 @@ train.py: data config
 ^^^^^^^^^^^^^^^^^^^^^^
 
 - New parameter: ``max_time_frames`` specifies maximum number of time frames. You can set non-negative values to limit the maximum time frames for making a mini-batch. It would be useful to workaround GPU OOM issues.
+- New parameter: ``filter_long_segments`` specifies if long segments are filtered or not. Consider to set it True when you have GPU OOM issues. Default is False.
+- New parameter: ``filter_num_frames`` specifies the threshold for filtering long segments. Default is 6000, which means segments longer than 30 sec will not be used for training.
 
 
 train_resf0.py: train config

--- a/nnsvs/bin/conf/train/data/defaults.yaml
+++ b/nnsvs/bin/conf/train/data/defaults.yaml
@@ -13,6 +13,12 @@ num_workers: 2
 batch_size: 8
 pin_memory: true
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # mini-batch sampling
 # If max_time_frames is specified, (max_time_frames) frames are randomly sampled
 # to create a mini-batch. Otherwise, all frames are used.

--- a/nnsvs/bin/conf/train_postfilter/data/defaults.yaml
+++ b/nnsvs/bin/conf/train_postfilter/data/defaults.yaml
@@ -13,6 +13,12 @@ num_workers: 2
 batch_size: 2
 pin_memory: true
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # mini-batch sampling
 # If max_time_frames is specified, (max_time_frames) frames are randomly sampled
 # to create a mini-batch. Otherwise, all frames are used.

--- a/nnsvs/bin/conf/train_resf0/data/defaults.yaml
+++ b/nnsvs/bin/conf/train_resf0/data/defaults.yaml
@@ -13,6 +13,12 @@ num_workers: 2
 batch_size: 8
 pin_memory: true
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # NOTE: the following parameters must be carefully set
 # log-F0 and rest parameter indices in the input features
 # it depends on the hed file

--- a/nnsvs/bin/generate.py
+++ b/nnsvs/bin/generate.py
@@ -43,7 +43,7 @@ def my_app(config: DictConfig) -> None:
 
     scaler = joblib.load(to_absolute_path(config.out_scaler_path))
 
-    in_feats = FileSourceDataset(NpyFileSource(in_dir))
+    in_feats = FileSourceDataset(NpyFileSource(in_dir, logger))
 
     with torch.no_grad():
         for idx in tqdm(range(len(in_feats))):

--- a/recipes/_common/conf/jp_dev_latest/train/duration/data/myconfig.yaml
+++ b/recipes/_common/conf/jp_dev_latest/train/duration/data/myconfig.yaml
@@ -13,6 +13,12 @@ num_workers: 2
 batch_size: 8
 pin_memory: true
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # mini-batch sampling
 # If max_time_frames is specified, (max_time_frames) frames are randomly sampled
 # to create a mini-batch. Otherwise, all frames are used.

--- a/recipes/_common/conf/jp_dev_latest/train/duration/data/test.yaml
+++ b/recipes/_common/conf/jp_dev_latest/train/duration/data/test.yaml
@@ -13,6 +13,12 @@ num_workers: 0
 batch_size: 2
 pin_memory: true
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # mini-batch sampling
 # If max_time_frames is specified, (max_time_frames) frames are randomly sampled
 # to create a mini-batch. Otherwise, all frames are used.

--- a/recipes/_common/conf/jp_dev_latest/train/timelag/data/myconfig.yaml
+++ b/recipes/_common/conf/jp_dev_latest/train/timelag/data/myconfig.yaml
@@ -13,6 +13,12 @@ num_workers: 2
 batch_size: 8
 pin_memory: true
 
+# Filter long semgnets that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # mini-batch sampling
 # If max_time_frames is specified, (max_time_frames) frames are randomly sampled
 # to create a mini-batch. Otherwise, all frames are used.

--- a/recipes/_common/conf/jp_dev_latest/train_postfilter/data/myconfig.yaml
+++ b/recipes/_common/conf/jp_dev_latest/train_postfilter/data/myconfig.yaml
@@ -13,6 +13,12 @@ num_workers: 2
 batch_size: 2
 pin_memory: true
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 in_scaler_path: null
 out_scaler_path: null
 

--- a/recipes/_common/conf/jp_dev_latest/train_postfilter/data/test.yaml
+++ b/recipes/_common/conf/jp_dev_latest/train_postfilter/data/test.yaml
@@ -13,6 +13,12 @@ num_workers: 0
 batch_size: 2
 pin_memory: true
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 in_scaler_path: null
 out_scaler_path: null
 

--- a/recipes/_common/conf/jp_dev_latest/train_resf0/acoustic/data/myconfig.yaml
+++ b/recipes/_common/conf/jp_dev_latest/train_resf0/acoustic/data/myconfig.yaml
@@ -15,6 +15,12 @@ pin_memory: true
 
 sample_rate: 48000
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # mini-batch sampling
 # If max_time_frames is specified, (max_time_frames) frames are randomly sampled
 # to create a mini-batch. Otherwise, all frames are used.

--- a/recipes/_common/conf/jp_dev_latest/train_resf0/acoustic/data/test.yaml
+++ b/recipes/_common/conf/jp_dev_latest/train_resf0/acoustic/data/test.yaml
@@ -15,6 +15,12 @@ pin_memory: true
 
 sample_rate: 48000
 
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+
 # mini-batch sampling
 # If max_time_frames is specified, (max_time_frames) frames are randomly sampled
 # to create a mini-batch. Otherwise, all frames are used.


### PR DESCRIPTION
this prevents GPU OOM errors when the training data contains some long segments

disabled by default to keep backward compatibility

particularly useful for training big models like #129 