### PR TITLE
Wrong device assignment of svs.py

### DIFF
--- a/nnsvs/svs.py
+++ b/nnsvs/svs.py
@@ -334,10 +334,10 @@ WORLD is only supported for waveform generation"""
 
         # Learned post-filter using nnsvs
         if post_filter_type == "nnsvs" and self.postfilter_model is not None:
+            in_feats = torch.from_numpy(acoustic_features).float().unsqueeze(0)
             in_feats = (
-                torch.from_numpy(acoustic_features).float().unsqueeze(0)
+                self.postfilter_out_scaler.transform(in_feats).float().to(self.device)
             )
-            in_feats = self.postfilter_out_scaler.transform(in_feats).float().to(self.device)
             out_feats = self.postfilter_model.inference(in_feats, [in_feats.shape[1]])
             acoustic_features = (
                 self.postfilter_out_scaler.inverse_transform(out_feats.cpu())

--- a/nnsvs/svs.py
+++ b/nnsvs/svs.py
@@ -335,14 +335,13 @@ WORLD is only supported for waveform generation"""
         # Learned post-filter using nnsvs
         if post_filter_type == "nnsvs" and self.postfilter_model is not None:
             in_feats = (
-                torch.from_numpy(acoustic_features).float().to(self.device).unsqueeze(0)
+                torch.from_numpy(acoustic_features).float().unsqueeze(0)
             )
-            in_feats = self.postfilter_out_scaler.transform(in_feats).float()
+            in_feats = self.postfilter_out_scaler.transform(in_feats).float().to(self.device)
             out_feats = self.postfilter_model.inference(in_feats, [in_feats.shape[1]])
             acoustic_features = (
-                self.postfilter_out_scaler.inverse_transform(out_feats)
+                self.postfilter_out_scaler.inverse_transform(out_feats.cpu())
                 .squeeze(0)
-                .cpu()
                 .numpy()
             )
 


### PR DESCRIPTION
Hello.

In svs.py, it is better to set device of in_feats/out_feats to "cpu" before applying transform/invers_transform of postfilter_out_scaler.  This PR will fix it.