### PR TITLE
Add recipes for reproducing experiments reported in our NNSVS paper

### DIFF
--- a/recipes/_common/hed/jp_icassp2023.hed
+++ b/recipes/_common/hed/jp_icassp2023.hed
@@ -1,0 +1,109 @@
+# Feature dim:: 86 for acoustic model, 82 for duration/timelag
+# in_rest_idx: 0
+# in_lf0_idx: 51
+
+QS "C-Phone_Muon"     {*-sil+*,*-pau+*}
+
+QS "C-VUV_Voiced" {*-a+*,*-i+*,*-u+*,*-e+*,*-o+*,*-v+*,*-b+*,*-by+*,*-m+*,*-my+*,*-w+*,*-z+*,*-j+*,*-d+*,*-dy+*,*-n+*,*-ny+*,*-N+*,*-r+*,*-ry+*,*-g+*,*-gy+*,*-y+*}
+# NOTE: rename "C-NOFIX_VUV_Unvoiced" to "C-VUV_Unvoiced" to enable auto correcting unvoied phonemes
+QS "C-NOFIX_VUV_Unvoiced"  {*-A+*,*-I+*,*-U+*,*-E+*,*-O+*,*-f+*,*-p+*,*-py+*,*-s+*,*-sh+*,*-ts+*,*-ch+*,*-t+*,*-ty+*,*-k+*,*-ky+*,*-h+*,*-hy+*}
+
+QS "C-Phone_sil" {*-sil+*}
+QS "C-Phone_pau" {*-pau+*}
+QS "C-Phone_A"   {*-A+*}
+QS "C-Phone_E"   {*-E+*}
+QS "C-Phone_I"   {*-I+*}
+QS "C-Phone_N"   {*-N+*}
+QS "C-Phone_O"   {*-O+*}
+QS "C-Phone_U"   {*-U+*}
+QS "C-Phone_a"   {*-a+*}
+QS "C-Phone_b"   {*-b+*}
+QS "C-Phone_br"  {*-br+*}
+QS "C-Phone_by"  {*-by+*}
+QS "C-Phone_ch"  {*-ch+*}
+QS "C-Phone_cl"  {*-cl+*}
+QS "C-Phone_d"   {*-d+*}
+QS "C-Phone_dy"  {*-dy+*}
+QS "C-Phone_e"   {*-e+*}
+QS "C-Phone_f"   {*-f+*}
+QS "C-Phone_g"   {*-g+*}
+QS "C-Phone_gy"  {*-gy+*}
+QS "C-Phone_h"   {*-h+*}
+QS "C-Phone_hy"  {*-hy+*}
+QS "C-Phone_i"   {*-i+*}
+QS "C-Phone_j"   {*-j+*}
+QS "C-Phone_k"   {*-k+*}
+QS "C-Phone_ky"  {*-ky+*}
+QS "C-Phone_m"   {*-m+*}
+QS "C-Phone_my"  {*-my+*}
+QS "C-Phone_n"   {*-n+*}
+QS "C-Phone_ny"  {*-ny+*}
+QS "C-Phone_o"   {*-o+*}
+QS "C-Phone_p"   {*-p+*}
+QS "C-Phone_py"  {*-py+*}
+QS "C-Phone_r"   {*-r+*}
+QS "C-Phone_ry"  {*-ry+*}
+QS "C-Phone_s"   {*-s+*}
+QS "C-Phone_sh"  {*-sh+*}
+QS "C-Phone_t"   {*-t+*}
+QS "C-Phone_ts"  {*-ts+*}
+QS "C-Phone_ty"  {*-ty+*}
+QS "C-Phone_u"   {*-u+*}
+QS "C-Phone_v"   {*-v+*}
+QS "C-Phone_w"   {*-w+*}
+QS "C-Phone_y"   {*-y+*}
+QS "C-Phone_z"   {*-z+*}
+QS "C-Phone_GlottalStop"   {*-GlottalStop+*}
+QS "C-Phone_Edge"          {*-Edge+*}
+
+# absolute pitch (L/C/R)
+CQS "d1" {/D:(\NOTE)!}
+CQS "e1" {/E:(\NOTE)]}
+CQS "f1" {/F:(\NOTE)#}
+
+# relative pitch (C)
+CQS "e2" {](\d+)^}
+
+# phoneme-level positional features (C)
+CQS "p12" {-(\d+)!}
+CQS "p13" {!(\d+)[}
+
+# distance between consonant and vowel
+CQS "p14" {[(\d+)$}
+CQS "p15" {$(\d+)]}
+
+# number of phonemes in a syllable (C)
+CQS "b1" {/B:(\d+)_}
+
+# syllable potional features (C)
+CQS "b2" {_(\d+)_}
+CQS "b3" {_(\d+)@}
+
+# length of current note (C)
+CQS "e6" {!(\d+)@}
+CQS "e7" {@(\d+)#}
+CQS "e8" {#(\d+)+}
+
+# note-level positional features in measures (C)
+CQS "e10_position_by_note_in_measure"      {](\d+)$}
+CQS "e11_position_by_note_in_measure"      {$(\d+)|}
+CQS "e12_position_by_10ms_in_measure"      {|(\d+)[}
+CQS "e13_position_by_10ms_in_measure"      {[(\d+)&}
+CQS "e14_position_by_96th_note_in_measure" {&(\d+)]}
+CQS "e15_position_by_96th_note_in_measure" {](\d+)=}
+CQS "e16_position_by_percent_in_measure"   {=(\d+)^}
+CQS "e17_position_by_percent_in_measure"   {^(\d+)~}
+
+# note-level positional features in phrase (C)
+CQS "e18_position_by_note"      {~(\d+)#}
+CQS "e19_position_by_note"      {#(\d+)_}
+CQS "e20_position_by_10ms"      {_(\d+);}
+CQS "e21_position_by_10ms"      {;(\d+)$}
+CQS "e22_position_by_96th_note" {$(\d+)&}
+CQS "e23_position_by_96th_note" {&(\d+)%}
+CQS "e24_position_by_percent"   {%(\d+)[}
+CQS "e25_position_by_percent"   {[(\d+)|}
+
+# pitch diff
+CQS "e57" {~([pm]\d+)+}
+CQS "e58" {+([pm]\d+)!}

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/README.md
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/README.md
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/README.md

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/anasyn_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/anasyn_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/anasyn_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/conf
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/conf
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/conf

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/config.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/config.yaml
@@ -1,0 +1,139 @@
+### General settings.
+## The name of singer
+spk: "namine_ritsu"
+
+## exp tag(for managing experiments)
+tag:
+
+## Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: "~/data/「波音リツ」歌声データベースVer2"
+
+## Output directory
+# All the generated labels, intermediate files, and segmented wav files
+# will be saved in the following directory
+out_dir: "./data"
+
+## Songs to be excluded from training.
+exclude_songs: []
+
+### Utaupy related settings.
+## Utaupy table path
+# This singing voice database contains the unvoiced vowels "I" and "U".
+# To enable the unvoiced vowels, modified version of sinsy dictionary files
+# are needed.
+utaupy_table_path: "../../_common/no2/utaupy/kana2phonemes_002_oto2lab.table"
+
+## HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/jp_icassp2023.hed"
+
+### Data preparation related settings.
+## Song segmentation by silence durations.
+# Split song by silences (in sec)
+segmentation_threshold: 0.1
+# Min duration for a segment
+# note: there could be some exceptions (e.g., the last segment of a song)
+segment_min_duration: 5.0
+# Force split segments if long silence is found regardless of min_duration
+force_split_threshold: 5.0
+# Offset correction
+# If True, offset is computed in an entire song
+# otherwise offset is computed for each segment
+global_offset_correction: False
+offset_correction_threshold: 0.01
+# Time-lag constraints to filter outliers
+timelag_allowed_range: [-20, 19]
+timelag_allowed_range_rest: [-40, 39]
+
+suppress_start_end_pau: True
+start_end_pau_suppression_ratio: 0.2
+
+# Audio sampling rate
+# CAUTION: Changing sample_rate may affect the dimension number of acoustic features.
+# DO NOT CHANGE this unless you know the relationship between the dim of bap and sample_rate.
+sample_rate: 24000
+
+gain_normalize: False
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: nnsvs_contrib_melf0_24k_diffsinger_compat
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_vp_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_vp_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_nnsvs_ar
+acoustic_train: myconfig
+acoustic_data: melf0
+
+postfilter_model: postfilter_mgc
+postfilter_train: mgc
+postfilter_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+# Advanced settings for hyperparameter search with Hydra and Optuna.
+# https://hydra.cc/docs/plugins/optuna_sweeper/
+# NOTE: Don't use spaces for each search space configuration.
+# OK: data.batch_size=range(1,16)
+# NG: data.batch_size=range(1, 16)
+# Example 1: data.batch_size=range(1,16) model.netG.hidden_dim=choice(32,64,128)
+# Example 2: train.optim.optimizer.params.lr=interval(0.0001,0.01)
+timelag_hydra_optuna_sweeper_args:
+timelag_hydra_optuna_sweeper_n_trials: 100
+duration_hydra_optuna_sweeper_args:
+duration_hydra_optuna_sweeper_n_trials: 100
+acoustic_hydra_optuna_sweeper_args:
+acoustic_hydra_optuna_sweeper_n_trials: 100
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+# conf/synthesis/synthesis/${synthesis}
+synthesis: world_gv
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth
+postfilter_eval_checkpoint: latest.pth
+
+###########################################################
+#                VOCODER SETTING                          #
+###########################################################
+
+# NOTE: conf/parallel_wavegan/${vocoder_model}.yaml must exist.
+vocoder_model:
+# Pretrained checkpoint path for the vocoder model
+# NOTE: if you want to try fine-tuning, please specify the path here
+pretrained_vocoder_checkpoint:
+# absolute/relative path to the checkpoint
+# NOTE: the checkpoint is used for synthesis and packing
+# This doesn't have any effect on training
+vocoder_eval_checkpoint:

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/run.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/run.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/run.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/synthesis_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel-diffsinger-compat/synthesis_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/synthesis_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/README.md
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/README.md
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/README.md

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/anasyn_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/anasyn_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/anasyn_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/conf
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/conf
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/conf

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/config.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/config.yaml
@@ -1,0 +1,139 @@
+### General settings.
+## The name of singer
+spk: "namine_ritsu"
+
+## exp tag(for managing experiments)
+tag:
+
+## Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: "~/data/「波音リツ」歌声データベースVer2"
+
+## Output directory
+# All the generated labels, intermediate files, and segmented wav files
+# will be saved in the following directory
+out_dir: "./data"
+
+## Songs to be excluded from training.
+exclude_songs: []
+
+### Utaupy related settings.
+## Utaupy table path
+# This singing voice database contains the unvoiced vowels "I" and "U".
+# To enable the unvoiced vowels, modified version of sinsy dictionary files
+# are needed.
+utaupy_table_path: "../../_common/no2/utaupy/kana2phonemes_002_oto2lab.table"
+
+## HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/jp_icassp2023.hed"
+
+### Data preparation related settings.
+## Song segmentation by silence durations.
+# Split song by silences (in sec)
+segmentation_threshold: 0.1
+# Min duration for a segment
+# note: there could be some exceptions (e.g., the last segment of a song)
+segment_min_duration: 5.0
+# Force split segments if long silence is found regardless of min_duration
+force_split_threshold: 5.0
+# Offset correction
+# If True, offset is computed in an entire song
+# otherwise offset is computed for each segment
+global_offset_correction: False
+offset_correction_threshold: 0.01
+# Time-lag constraints to filter outliers
+timelag_allowed_range: [-20, 19]
+timelag_allowed_range_rest: [-40, 39]
+
+suppress_start_end_pau: True
+start_end_pau_suppression_ratio: 0.2
+
+# Audio sampling rate
+# CAUTION: Changing sample_rate may affect the dimension number of acoustic features.
+# DO NOT CHANGE this unless you know the relationship between the dim of bap and sample_rate.
+sample_rate: 24000
+
+gain_normalize: False
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: nnsvs_contrib_melf0_24k
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_vp_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_vp_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_nnsvs_ar
+acoustic_train: myconfig
+acoustic_data: melf0
+
+postfilter_model: postfilter_mgc
+postfilter_train: mgc
+postfilter_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+# Advanced settings for hyperparameter search with Hydra and Optuna.
+# https://hydra.cc/docs/plugins/optuna_sweeper/
+# NOTE: Don't use spaces for each search space configuration.
+# OK: data.batch_size=range(1,16)
+# NG: data.batch_size=range(1, 16)
+# Example 1: data.batch_size=range(1,16) model.netG.hidden_dim=choice(32,64,128)
+# Example 2: train.optim.optimizer.params.lr=interval(0.0001,0.01)
+timelag_hydra_optuna_sweeper_args:
+timelag_hydra_optuna_sweeper_n_trials: 100
+duration_hydra_optuna_sweeper_args:
+duration_hydra_optuna_sweeper_n_trials: 100
+acoustic_hydra_optuna_sweeper_args:
+acoustic_hydra_optuna_sweeper_n_trials: 100
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+# conf/synthesis/synthesis/${synthesis}
+synthesis: world_gv
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth
+postfilter_eval_checkpoint: latest.pth
+
+###########################################################
+#                VOCODER SETTING                          #
+###########################################################
+
+# NOTE: conf/parallel_wavegan/${vocoder_model}.yaml must exist.
+vocoder_model:
+# Pretrained checkpoint path for the vocoder model
+# NOTE: if you want to try fine-tuning, please specify the path here
+pretrained_vocoder_checkpoint:
+# absolute/relative path to the checkpoint
+# NOTE: the checkpoint is used for synthesis and packing
+# This doesn't have any effect on training
+vocoder_eval_checkpoint:

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/run.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/run.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/run.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/synthesis_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-mel/synthesis_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/synthesis_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/README.md
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/README.md
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/README.md

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/anasyn_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/anasyn_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/anasyn_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/conf
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/conf
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/conf

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/config.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/config.yaml
@@ -1,0 +1,139 @@
+### General settings.
+## The name of singer
+spk: "namine_ritsu"
+
+## exp tag(for managing experiments)
+tag:
+
+## Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: "~/data/「波音リツ」歌声データベースVer2"
+
+## Output directory
+# All the generated labels, intermediate files, and segmented wav files
+# will be saved in the following directory
+out_dir: "./data"
+
+## Songs to be excluded from training.
+exclude_songs: []
+
+### Utaupy related settings.
+## Utaupy table path
+# This singing voice database contains the unvoiced vowels "I" and "U".
+# To enable the unvoiced vowels, modified version of sinsy dictionary files
+# are needed.
+utaupy_table_path: "../../_common/no2/utaupy/kana2phonemes_002_oto2lab.table"
+
+## HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/jp_icassp2023.hed"
+
+### Data preparation related settings.
+## Song segmentation by silence durations.
+# Split song by silences (in sec)
+segmentation_threshold: 0.1
+# Min duration for a segment
+# note: there could be some exceptions (e.g., the last segment of a song)
+segment_min_duration: 5.0
+# Force split segments if long silence is found regardless of min_duration
+force_split_threshold: 5.0
+# Offset correction
+# If True, offset is computed in an entire song
+# otherwise offset is computed for each segment
+global_offset_correction: False
+offset_correction_threshold: 0.01
+# Time-lag constraints to filter outliers
+timelag_allowed_range: [-20, 19]
+timelag_allowed_range_rest: [-40, 39]
+
+suppress_start_end_pau: True
+start_end_pau_suppression_ratio: 0.2
+
+# Audio sampling rate
+# CAUTION: Changing sample_rate may affect the dimension number of acoustic features.
+# DO NOT CHANGE this unless you know the relationship between the dim of bap and sample_rate.
+sample_rate: 24000
+
+gain_normalize: False
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: nnsvs_contrib_static_only_diffvib
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_vp_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_vp_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_nnsvs_ar
+acoustic_train: myconfig
+acoustic_data: melf0
+
+postfilter_model: postfilter_mgc
+postfilter_train: mgc
+postfilter_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+# Advanced settings for hyperparameter search with Hydra and Optuna.
+# https://hydra.cc/docs/plugins/optuna_sweeper/
+# NOTE: Don't use spaces for each search space configuration.
+# OK: data.batch_size=range(1,16)
+# NG: data.batch_size=range(1, 16)
+# Example 1: data.batch_size=range(1,16) model.netG.hidden_dim=choice(32,64,128)
+# Example 2: train.optim.optimizer.params.lr=interval(0.0001,0.01)
+timelag_hydra_optuna_sweeper_args:
+timelag_hydra_optuna_sweeper_n_trials: 100
+duration_hydra_optuna_sweeper_args:
+duration_hydra_optuna_sweeper_n_trials: 100
+acoustic_hydra_optuna_sweeper_args:
+acoustic_hydra_optuna_sweeper_n_trials: 100
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+# conf/synthesis/synthesis/${synthesis}
+synthesis: world_gv
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth
+postfilter_eval_checkpoint: latest.pth
+
+###########################################################
+#                VOCODER SETTING                          #
+###########################################################
+
+# NOTE: conf/parallel_wavegan/${vocoder_model}.yaml must exist.
+vocoder_model:
+# Pretrained checkpoint path for the vocoder model
+# NOTE: if you want to try fine-tuning, please specify the path here
+pretrained_vocoder_checkpoint:
+# absolute/relative path to the checkpoint
+# NOTE: the checkpoint is used for synthesis and packing
+# This doesn't have any effect on training
+vocoder_eval_checkpoint:

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/run.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/run.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/run.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/synthesis_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-diffvib/synthesis_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/synthesis_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/README.md
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/README.md
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/README.md

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/anasyn_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/anasyn_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/anasyn_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/conf
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/conf
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/conf

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/config.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/config.yaml
@@ -1,0 +1,139 @@
+### General settings.
+## The name of singer
+spk: "namine_ritsu"
+
+## exp tag(for managing experiments)
+tag:
+
+## Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: "~/data/「波音リツ」歌声データベースVer2"
+
+## Output directory
+# All the generated labels, intermediate files, and segmented wav files
+# will be saved in the following directory
+out_dir: "./data"
+
+## Songs to be excluded from training.
+exclude_songs: []
+
+### Utaupy related settings.
+## Utaupy table path
+# This singing voice database contains the unvoiced vowels "I" and "U".
+# To enable the unvoiced vowels, modified version of sinsy dictionary files
+# are needed.
+utaupy_table_path: "../../_common/no2/utaupy/kana2phonemes_002_oto2lab.table"
+
+## HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/jp_icassp2023.hed"
+
+### Data preparation related settings.
+## Song segmentation by silence durations.
+# Split song by silences (in sec)
+segmentation_threshold: 0.1
+# Min duration for a segment
+# note: there could be some exceptions (e.g., the last segment of a song)
+segment_min_duration: 5.0
+# Force split segments if long silence is found regardless of min_duration
+force_split_threshold: 5.0
+# Offset correction
+# If True, offset is computed in an entire song
+# otherwise offset is computed for each segment
+global_offset_correction: False
+offset_correction_threshold: 0.01
+# Time-lag constraints to filter outliers
+timelag_allowed_range: [-20, 19]
+timelag_allowed_range_rest: [-40, 39]
+
+suppress_start_end_pau: True
+start_end_pau_suppression_ratio: 0.2
+
+# Audio sampling rate
+# CAUTION: Changing sample_rate may affect the dimension number of acoustic features.
+# DO NOT CHANGE this unless you know the relationship between the dim of bap and sample_rate.
+sample_rate: 24000
+
+gain_normalize: False
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: nnsvs_contrib_static_only_sinevib
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_vp_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_vp_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_nnsvs_ar
+acoustic_train: myconfig
+acoustic_data: melf0
+
+postfilter_model: postfilter_mgc
+postfilter_train: mgc
+postfilter_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+# Advanced settings for hyperparameter search with Hydra and Optuna.
+# https://hydra.cc/docs/plugins/optuna_sweeper/
+# NOTE: Don't use spaces for each search space configuration.
+# OK: data.batch_size=range(1,16)
+# NG: data.batch_size=range(1, 16)
+# Example 1: data.batch_size=range(1,16) model.netG.hidden_dim=choice(32,64,128)
+# Example 2: train.optim.optimizer.params.lr=interval(0.0001,0.01)
+timelag_hydra_optuna_sweeper_args:
+timelag_hydra_optuna_sweeper_n_trials: 100
+duration_hydra_optuna_sweeper_args:
+duration_hydra_optuna_sweeper_n_trials: 100
+acoustic_hydra_optuna_sweeper_args:
+acoustic_hydra_optuna_sweeper_n_trials: 100
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+# conf/synthesis/synthesis/${synthesis}
+synthesis: world_gv
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth
+postfilter_eval_checkpoint: latest.pth
+
+###########################################################
+#                VOCODER SETTING                          #
+###########################################################
+
+# NOTE: conf/parallel_wavegan/${vocoder_model}.yaml must exist.
+vocoder_model:
+# Pretrained checkpoint path for the vocoder model
+# NOTE: if you want to try fine-tuning, please specify the path here
+pretrained_vocoder_checkpoint:
+# absolute/relative path to the checkpoint
+# NOTE: the checkpoint is used for synthesis and packing
+# This doesn't have any effect on training
+vocoder_eval_checkpoint:

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/run.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/run.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/run.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/synthesis_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world-sinevib/synthesis_icassp2023.sh
@@ -1,0 +1,1 @@
+../icassp2023-24k-world/synthesis_icassp2023.sh

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/README.md
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/README.md
@@ -1,0 +1,58 @@
+# Notes for reproducing experiments
+
+Paper: https://arxiv.org/abs/2210.15987.
+
+## Data
+
+Please normalize data to -26dB before running recipes. You can use sv56 to normalize audio signals.
+
+## Recipes
+
+- `icassp2023-24k-world`: Recipe using WORLD features. NNSVS-WORLD v1, v2, v3, v4, and Sinsy without vibrato modeling were trained with this recipe.
+- `icassp2023-24k-mel`: Recipe using mel-spectrogram. NNSVS-Mel v1, v2, and v3 were trained with this recipe.
+- `icassp2023-24k-mel-diffsinger-compat`: Recipe using mel-spectrogram. The feature extraction settings (e.g. FFT size) are the same as the [DiffSinger](https://github.com/MoonInTheRiver/DiffSinger). This recipe was used for training DiffSinger-compatible hn-HiFi-GAN.
+- `icassp2023-24k-world-sinevib`: Recipe using WORLD features with extra sine-based vibrato parameters. This recipe was used to build Sinsy with explicit vibrato modeling.
+- `icassp2023-24k-world-diffvib`: Recipe using WORLD features with extra diff-based vibrato parameters. We used this recipe only in our preliminary experiments.
+
+## Acoustic model configs
+
+The following table summarizes the names of acoustic model configurations used in our experiments.
+All the config files are stored inside the recipe directories.
+
+| System                      | Recipe                       | Acoustic model config                               |
+|-----------------------------|------------------------------|-----------------------------------------------------|
+| Sinsy                       | icassp2023-24k-world         | acoustic_sinsy_world_novib.yaml                     |
+| Sinsy (w/ pitch correction) | icassp2023-24k-world         | acoustic_sinsy_world_novib_pitchreg.yaml            |
+| Sinsy (w/ vibrato modeling) | icassp2023-24k-world-sinevib | acoustic_sinsy_world_sinevib_pitchreg.yaml          |
+| NNSVS-Mel v1                | icassp2023-24k-mel           | acoustic_nnsvs_melf0_multi_nonar.yaml               |
+| NNSVS-Mel v2                | icassp2023-24k-mel           | acoustic_nnsvs_melf0_multi_ar_f0.yaml               |
+| NNSVS-Mel v3                | icassp2023-24k-mel           | acoustic_nnsvs_melf0_multi_ar_melf0_prenet0.yaml    |
+| NNSVS-WORLD v1              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_nonar.yaml               |
+| NNSVS-WORLD v2              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_ar_f0.yaml               |
+| NNSVS-WORLD v3              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_ar_mgcf0_prenet0.yaml    |
+| NNSVS-WORLD v4              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1.yaml |
+
+
+## How to run recipes
+
+The same as the other recipes.
+
+## Run acoustic model training
+
+For example, to train NNSVS-WORLD v4, you can try the following command:
+
+```
+CUDA_VISIBLE_DEVICES=0 ./run.sh  --stage 4 --stop-stage 4 --tag 20220926_icassp_v3 --acoustic-model acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1 --acoustic-data myconfig
+```
+
+If you have a pre-trained uSFGAN model checkpoint, you could try:
+
+```
+CUDA_VISIBLE_DEVICES=0 ./run.sh  --stage 4 --stop-stage 4 --tag 20220926_icassp_v3 --acoustic-model acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1 --acoustic-data myconfig  --vocoder-eval-checkpoint $PWD/path/to/usfgan/checkpoint-600000steps.pkl
+```
+
+The above two commands are based on my command line history.
+
+## How to train uSFGAN vocoder
+
+TBD

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/anasyn_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/anasyn_icassp2023.sh
@@ -1,0 +1,47 @@
+# NOTE: the script is supposed to be used called from nnsvs recipes.
+# Please don't try to run the shell script directory.
+
+if [ -d conf/synthesis ]; then
+    ext="--config-dir conf/synthesis"
+else
+    ext=""
+fi
+
+if [ -z $timelag_eval_checkpoint ]; then
+    timelag_eval_checkpoint=best_loss.pth
+fi
+if [ -z $duration_eval_checkpoint ]; then
+    duration_eval_checkpoint=best_loss.pth
+fi
+if [ -z $acoustic_eval_checkpoint ]; then
+    acoustic_eval_checkpoint=latest.pth
+fi
+
+if [ -z "${vocoder_eval_checkpoint}" ]; then
+    if [ ! -z "${vocoder_model}" ]; then
+        vocoder_eval_checkpoint="$(ls -dt "${expdir}/${vocoder_model}"/*.pkl | head -1 || true)"
+    fi
+fi
+
+if [ -z "${vocoder_eval_checkpoint}" ]; then
+    dst_name=anasyn_world
+else
+    if [ ! -z "${vocoder_model}" ]; then
+        dst_name=anasyn_${vocoder_model}_${synthesis}
+    else
+        vocoder_name=$(dirname ${vocoder_eval_checkpoint})
+        vocoder_name=$(basename $vocoder_name)
+        dst_name=anasyn_${vocoder_name}_${synthesis}
+    fi
+fi
+
+for s in ${testsets[@]}; do
+    xrun python $NNSVS_ROOT/nnsvs_contrib/bin/anasyn.py $ext \
+        synthesis=$synthesis \
+        synthesis.sample_rate=$sample_rate \
+        acoustic.model_yaml=$expdir/${acoustic_model}/model.yaml \
+        vocoder.checkpoint=$vocoder_eval_checkpoint \
+        utt_list=./data/list/$s.list \
+        in_dir=$dump_org_dir/$s/out_acoustic \
+        out_dir=$expdir/$dst_name/$s/
+done

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/parallel_wavegan/hn-sinc-hifigan_sr24k_mel_diffsinger_compat.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/parallel_wavegan/hn-sinc-hifigan_sr24k_mel_diffsinger_compat.yaml
@@ -1,0 +1,172 @@
+# This config is for 24kHz sampling audio with hop size of 128
+# conditional features: [mel, lf0, vuv]
+# stream sizes: [80, 1, 1]
+# should be compatible with https://github.com/MoonInTheRiver/DiffSinger
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+sampling_rate: 24000     # Sampling rate.
+fft_size: 512            # FFT size.
+hop_size: 128            # Hop size.
+win_length: 512          # Window length.
+                         # If set to null, it will be the same as fft_size.
+window: "hann"           # Window function.
+num_mels: 80            # Number of mel basis.
+fmin: 30                  # Minimum freq in mel basis calculation.
+fmax: 12000              # Maximum frequency in mel basis calculation.
+global_gain_scale: 1.0   # Will be multiplied to all of waveform.
+trim_silence: false      # Whether to trim the start and end of silence.
+trim_threshold_in_db: 60 # Need to tune carefully if the recording is not good.
+trim_frame_size: 2048    # Frame size in trimming.
+trim_hop_size: 512       # Hop size in trimming.
+format: "npy"            # Feature file format. "npy" or "hdf5" is supported.
+
+###########################################################
+#         GENERATOR NETWORK ARCHITECTURE SETTING          #
+###########################################################
+generator_type: HnSincHifiGanGenerator
+generator_params:
+    sample_rate: 24000
+    out_channels: 1
+    cin_channels: 80
+    out_lf0_idx: 80
+    out_lf0_mean: 5.93164897214654
+    out_lf0_scale: 0.29072533332452466
+    # NOTE: make sure to set this true to be compatible with DiffSinger's impl.
+    drop_melf0vuv: true
+    resblock: "1"
+    resblock_kernel_sizes: [3, 7, 11]
+    upsample_rates: [8, 4, 2, 2]
+    upsample_kernel_sizes: [16, 16, 4, 4]
+    upsample_initial_channel: 512
+    resblock_dilation_sizes: [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
+
+###########################################################
+#       DISCRIMINATOR NETWORK ARCHITECTURE SETTING        #
+###########################################################
+discriminator_type: HiFiGANMultiScaleMultiPeriodDiscriminator
+discriminator_params:
+    scales: 3                              # Number of multi-scale discriminator.
+    scale_downsample_pooling: "AvgPool1d"  # Pooling operation for scale discriminator.
+    scale_downsample_pooling_params:
+        kernel_size: 4                     # Pooling kernel size.
+        stride: 2                          # Pooling stride.
+        padding: 2                         # Padding size.
+    scale_discriminator_params:
+        in_channels: 1                     # Number of input channels.
+        out_channels: 1                    # Number of output channels.
+        kernel_sizes: [15, 41, 5, 3]       # List of kernel sizes.
+        channels: 128                      # Initial number of channels.
+        max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
+        max_groups: 16                     # Maximum number of groups in downsampling conv layers.
+        bias: true
+        downsample_scales: [4, 4, 4, 4, 1] # Downsampling scales.
+        nonlinear_activation: "LeakyReLU"  # Nonlinear activation.
+        nonlinear_activation_params:
+            negative_slope: 0.1
+    follow_official_norm: true             # Whether to follow the official norm setting.
+    periods: [2, 3, 5, 7, 11]              # List of period for multi-period discriminator.
+    period_discriminator_params:
+        in_channels: 1                     # Number of input channels.
+        out_channels: 1                    # Number of output channels.
+        kernel_sizes: [5, 3]               # List of kernel sizes.
+        channels: 32                       # Initial number of channels.
+        downsample_scales: [3, 3, 3, 3, 1] # Downsampling scales.
+        max_downsample_channels: 1024      # Maximum number of channels in downsampling conv layers.
+        bias: true                         # Whether to use bias parameter in conv layer."
+        nonlinear_activation: "LeakyReLU"  # Nonlinear activation.
+        nonlinear_activation_params:       # Nonlinear activation parameters.
+            negative_slope: 0.1
+        use_weight_norm: true              # Whether to apply weight normalization.
+        use_spectral_norm: false           # Whether to apply spectral normalization.
+
+###########################################################
+#                   STFT LOSS SETTING                     #
+###########################################################
+use_stft_loss: false                 # Whether to use multi-resolution STFT loss.
+use_mel_loss: true                   # Whether to use Mel-spectrogram loss.
+mel_loss_params:
+    fs: 24000
+    fft_size: 512            # FFT size.
+    hop_size: 128            # Hop size.
+    win_length: 512          # Window length.
+    window: "hann"
+    num_mels: 80
+    fmin: 30
+    fmax: 12000
+    log_base: null
+generator_adv_loss_params:
+    average_by_discriminators: false # Whether to average loss by #discriminators.
+discriminator_adv_loss_params:
+    average_by_discriminators: false # Whether to average loss by #discriminators.
+use_feat_match_loss: true
+feat_match_loss_params:
+    average_by_discriminators: false # Whether to average loss by #discriminators.
+    average_by_layers: false         # Whether to average loss by #layers in each discriminator.
+    include_final_outputs: false     # Whether to include final outputs in feat match loss calculation.
+
+###########################################################
+#               ADVERSARIAL LOSS SETTING                  #
+###########################################################
+lambda_aux: 45.0       # Loss balancing coefficient for STFT loss.
+lambda_adv: 1.0        # Loss balancing coefficient for adversarial loss.
+lambda_feat_match: 2.0 # Loss balancing coefficient for feat match loss..
+
+###########################################################
+#                  DATA LOADER SETTING                    #
+###########################################################
+batch_size: 8              # Batch size.
+batch_max_steps: 24000      # Length of each audio in batch. Make sure dividable by hop_size.
+pin_memory: true            # Whether to pin memory in Pytorch DataLoader.
+num_workers: 2              # Number of workers in Pytorch DataLoader.
+remove_short_samples: false # Whether to remove samples the length of which are less than batch_max_steps.
+allow_cache: true           # Whether to allow cache in dataset. If true, it requires cpu memory.
+
+###########################################################
+#             OPTIMIZER & SCHEDULER SETTING               #
+###########################################################
+generator_optimizer_type: Adam
+generator_optimizer_params:
+    lr: 2.0e-4
+    betas: [0.5, 0.9]
+    weight_decay: 0.0
+generator_scheduler_type: MultiStepLR
+generator_scheduler_params:
+    gamma: 0.5
+    milestones:
+        - 200000
+        - 400000
+        - 600000
+        - 800000
+generator_grad_norm: -1
+discriminator_optimizer_type: Adam
+discriminator_optimizer_params:
+    lr: 2.0e-4
+    betas: [0.5, 0.9]
+    weight_decay: 0.0
+discriminator_scheduler_type: MultiStepLR
+discriminator_scheduler_params:
+    gamma: 0.5
+    milestones:
+        - 200000
+        - 400000
+        - 600000
+        - 800000
+discriminator_grad_norm: -1 # Discriminator's gradient norm.
+
+###########################################################
+#                    INTERVAL SETTING                     #
+###########################################################
+generator_train_start_steps: 1     # Number of steps to start to train discriminator
+discriminator_train_start_steps: 0 # Number of steps to start to train discriminator.
+train_max_steps: 1000000           # Number of training steps.
+save_interval_steps: 50000         # Interval steps to save checkpoint.
+eval_interval_steps: 1000          # Interval steps to evaluate the network.
+log_interval_steps: 100            # Interval steps to record the training log.
+
+###########################################################
+#                     OTHER SETTING                       #
+###########################################################
+num_save_intermediate_results: 4  # Number of results to be saved as intermediate results.
+

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/parallel_wavegan/hn-sinc-nsf_sr24k_mel_pwgD.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/parallel_wavegan/hn-sinc-nsf_sr24k_mel_pwgD.yaml
@@ -1,0 +1,125 @@
+# This config is for 24kHz sampling audio with 5ms shift.
+# Generator: hn-sinc-nsf
+# Discriminator: PWG's discriminator
+# conditional features: [mgc, lf0, vuv, bap]
+# stream sizes: [60, 1, 1, 3]
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+sampling_rate: 24000     # Sampling rate.
+fft_size: 512            # FFT size.
+hop_size: 120            # Hop size.
+win_length: 480          # Window length.
+                         # If set to null, it will be the same as fft_size.
+window: "hann"           # Window function.
+num_mels: 80             # Number of mel basis.
+fmin: 63                 # Minimum freq in mel basis calculation.
+fmax: 12000              # Maximum frequency in mel basis calculation.
+global_gain_scale: 1.0   # Will be multiplied to all of waveform.
+trim_silence: false      # Whether to trim the start and end of silence.
+trim_threshold_in_db: 60 # Need to tune carefully if the recording is not good.
+trim_frame_size: 2048    # Frame size in trimming.
+trim_hop_size: 512       # Hop size in trimming.
+format: "npy"            # Feature file format. "npy" or "hdf5" is supported.
+
+###########################################################
+#         GENERATOR NETWORK ARCHITECTURE SETTING          #
+###########################################################
+generator_type: HnSincNSF
+generator_params:
+    sample_rate: 24000
+    upsample_rate: 120
+    cin_channels: 82
+    out_channels: 1
+    out_lf0_idx: 80
+    out_lf0_mean: 5.931693124747519
+    out_lf0_scale: 0.2906922702594673
+    out_vuv_idx: 81
+    sine_amp: 0.1
+    noise_std: 0.003
+    hidden_dim: 64
+    cnn_kernel_s: 5
+    filter_block_num: 5
+    cnn_num_in_block: 10
+    harmonic_num: 7
+    sinc_order: 31
+    # NOTE: leave empty for `upsample_net` to use NSF-style upsampling
+    upsample_net:
+    upsample_params:
+
+###########################################################
+#       DISCRIMINATOR NETWORK ARCHITECTURE SETTING        #
+###########################################################
+discriminator_params:
+    in_channels: 1        # Number of input channels.
+    out_channels: 1       # Number of output channels.
+    kernel_size: 3        # Number of output channels.
+    layers: 10            # Number of conv layers.
+    conv_channels: 64     # Number of chnn layers.
+    bias: true            # Whether to use bias parameter in conv.
+    use_weight_norm: true # Whether to use weight norm.
+                          # If set to true, it will be applied to all of the conv layers.
+    nonlinear_activation: "LeakyReLU" # Nonlinear function after each conv.
+    nonlinear_activation_params:      # Nonlinear function parameters
+        negative_slope: 0.2           # Alpha in LeakyReLU.
+
+###########################################################
+#                   STFT LOSS SETTING                     #
+###########################################################
+stft_loss_params:
+    fft_sizes: [1024, 2048, 256]  # List of FFT size for STFT-based loss.
+    hop_sizes: [120, 240, 50]     # List of hop size for STFT-based loss
+    win_lengths: [600, 1200, 240] # List of window length for STFT-based loss.
+    window: "hann_window"        # Window function for STFT-based loss
+
+###########################################################
+#               ADVERSARIAL LOSS SETTING                  #
+###########################################################
+lambda_adv: 4.0  # Loss balancing coefficient.
+
+###########################################################
+#                  DATA LOADER SETTING                    #
+###########################################################
+batch_size: 8              # Batch size.
+batch_max_steps: 24000     # Length of each audio in batch. Make sure dividable by hop_size.
+pin_memory: true           # Whether to pin memory in Pytorch DataLoader.
+num_workers: 2             # Number of workers in Pytorch DataLoader.
+remove_short_samples: true # Whether to remove samples the length of which are less than batch_max_steps.
+allow_cache: true          # Whether to allow cache in dataset. If true, it requires cpu memory.
+
+###########################################################
+#             OPTIMIZER & SCHEDULER SETTING               #
+###########################################################
+generator_optimizer_params:
+    lr: 0.0001             # Generator's learning rate.
+    eps: 1.0e-6            # Generator's epsilon.
+    weight_decay: 0.0      # Generator's weight decay coefficient.
+generator_scheduler_params:
+    step_size: 200000      # Generator's scheduler step size.
+    gamma: 0.5             # Generator's scheduler gamma.
+                           # At each step size, lr will be multiplied by this parameter.
+generator_grad_norm: 10    # Generator's gradient norm.
+discriminator_optimizer_params:
+    lr: 0.0001             # Discriminator's learning rate.
+    eps: 1.0e-6            # Discriminator's epsilon.
+    weight_decay: 0.0      # Discriminator's weight decay coefficient.
+discriminator_scheduler_params:
+    step_size: 200000      # Discriminator's scheduler step size.
+    gamma: 0.5             # Discriminator's scheduler gamma.
+                           # At each step size, lr will be multiplied by this parameter.
+discriminator_grad_norm: 1 # Discriminator's gradient norm.
+
+###########################################################
+#                    INTERVAL SETTING                     #
+###########################################################
+discriminator_train_start_steps: 100000 # Number of steps to start to train discriminator.
+train_max_steps: 400000                 # Number of training steps.
+save_interval_steps: 10000              # Interval steps to save checkpoint.
+eval_interval_steps: 1000               # Interval steps to evaluate the network.
+log_interval_steps: 100                 # Interval steps to record the training log.
+
+###########################################################
+#                     OTHER SETTING                       #
+###########################################################
+num_save_intermediate_results: 4  # Number of results to be saved as intermediate results.

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/parallel_wavegan/hn-sinc-nsf_sr24k_world_pwgD.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/parallel_wavegan/hn-sinc-nsf_sr24k_world_pwgD.yaml
@@ -1,0 +1,125 @@
+# This config is for 24kHz sampling audio with 5ms shift.
+# Generator: hn-sinc-nsf
+# Discriminator: PWG's discriminator
+# conditional features: [mgc, lf0, vuv, bap]
+# stream sizes: [60, 1, 1, 3]
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+sampling_rate: 24000     # Sampling rate.
+fft_size: 512            # FFT size.
+hop_size: 120            # Hop size.
+win_length: 512          # Window length.
+                         # If set to null, it will be the same as fft_size.
+window: "hann"           # Window function.
+num_mels: 80             # Number of mel basis.
+fmin: 0                  # Minimum freq in mel basis calculation.
+fmax: 12000              # Maximum frequency in mel basis calculation.
+global_gain_scale: 1.0   # Will be multiplied to all of waveform.
+trim_silence: false      # Whether to trim the start and end of silence.
+trim_threshold_in_db: 60 # Need to tune carefully if the recording is not good.
+trim_frame_size: 2048    # Frame size in trimming.
+trim_hop_size: 512       # Hop size in trimming.
+format: "npy"            # Feature file format. "npy" or "hdf5" is supported.
+
+###########################################################
+#         GENERATOR NETWORK ARCHITECTURE SETTING          #
+###########################################################
+generator_type: HnSincNSF
+generator_params:
+    sample_rate: 24000
+    upsample_rate: 120
+    cin_channels: 65
+    out_channels: 1
+    out_lf0_idx: 60
+    out_lf0_mean: 5.931693124747519
+    out_lf0_scale: 0.29069227025946676
+    out_vuv_idx: 61
+    sine_amp: 0.1
+    noise_std: 0.003
+    hidden_dim: 64
+    cnn_kernel_s: 5
+    filter_block_num: 5
+    cnn_num_in_block: 10
+    harmonic_num: 7
+    sinc_order: 31
+    # NOTE: leave empty for `upsample_net` to use NSF-style upsampling
+    upsample_net:
+    upsample_params:
+
+###########################################################
+#       DISCRIMINATOR NETWORK ARCHITECTURE SETTING        #
+###########################################################
+discriminator_params:
+    in_channels: 1        # Number of input channels.
+    out_channels: 1       # Number of output channels.
+    kernel_size: 3        # Number of output channels.
+    layers: 10            # Number of conv layers.
+    conv_channels: 64     # Number of chnn layers.
+    bias: true            # Whether to use bias parameter in conv.
+    use_weight_norm: true # Whether to use weight norm.
+                          # If set to true, it will be applied to all of the conv layers.
+    nonlinear_activation: "LeakyReLU" # Nonlinear function after each conv.
+    nonlinear_activation_params:      # Nonlinear function parameters
+        negative_slope: 0.2           # Alpha in LeakyReLU.
+
+###########################################################
+#                   STFT LOSS SETTING                     #
+###########################################################
+stft_loss_params:
+    fft_sizes: [1024, 2048, 256]  # List of FFT size for STFT-based loss.
+    hop_sizes: [120, 240, 50]     # List of hop size for STFT-based loss
+    win_lengths: [600, 1200, 240] # List of window length for STFT-based loss.
+    window: "hann_window"        # Window function for STFT-based loss
+
+###########################################################
+#               ADVERSARIAL LOSS SETTING                  #
+###########################################################
+lambda_adv: 4.0  # Loss balancing coefficient.
+
+###########################################################
+#                  DATA LOADER SETTING                    #
+###########################################################
+batch_size: 8              # Batch size.
+batch_max_steps: 24000     # Length of each audio in batch. Make sure dividable by hop_size.
+pin_memory: true           # Whether to pin memory in Pytorch DataLoader.
+num_workers: 2             # Number of workers in Pytorch DataLoader.
+remove_short_samples: true # Whether to remove samples the length of which are less than batch_max_steps.
+allow_cache: true          # Whether to allow cache in dataset. If true, it requires cpu memory.
+
+###########################################################
+#             OPTIMIZER & SCHEDULER SETTING               #
+###########################################################
+generator_optimizer_params:
+    lr: 0.0001             # Generator's learning rate.
+    eps: 1.0e-6            # Generator's epsilon.
+    weight_decay: 0.0      # Generator's weight decay coefficient.
+generator_scheduler_params:
+    step_size: 200000      # Generator's scheduler step size.
+    gamma: 0.5             # Generator's scheduler gamma.
+                           # At each step size, lr will be multiplied by this parameter.
+generator_grad_norm: 10    # Generator's gradient norm.
+discriminator_optimizer_params:
+    lr: 0.0001             # Discriminator's learning rate.
+    eps: 1.0e-6            # Discriminator's epsilon.
+    weight_decay: 0.0      # Discriminator's weight decay coefficient.
+discriminator_scheduler_params:
+    step_size: 200000      # Discriminator's scheduler step size.
+    gamma: 0.5             # Discriminator's scheduler gamma.
+                           # At each step size, lr will be multiplied by this parameter.
+discriminator_grad_norm: 1 # Discriminator's gradient norm.
+
+###########################################################
+#                    INTERVAL SETTING                     #
+###########################################################
+discriminator_train_start_steps: 100000 # Number of steps to start to train discriminator.
+train_max_steps: 400000                 # Number of training steps.
+save_interval_steps: 10000              # Interval steps to save checkpoint.
+eval_interval_steps: 1000               # Interval steps to evaluate the network.
+log_interval_steps: 100                 # Interval steps to record the training log.
+
+###########################################################
+#                     OTHER SETTING                       #
+###########################################################
+num_save_intermediate_results: 4  # Number of results to be saved as intermediate results.

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
@@ -1,0 +1,84 @@
+enabled: true
+question_path:
+wav_dir: data/acoustic/wav
+label_dir: data/acoustic/label_phone_align
+
+sample_rate: 48000
+
+# world or melf0
+feature_type: melf0
+
+# Resample type
+res_type: scipy
+
+subphone_features: coarse_coding
+
+# kiritan
+# min 174.61411571650194
+# max 659.2551138257398
+# If specified, use the values for F0 estimation.
+# Or, these are calculated from min/max notes in the musical score.
+f0_floor: null
+f0_ceil: null
+
+use_harvest: true
+d4c_threshold: 0.15
+
+frame_period: 5 # ms
+mgc_order: 59
+
+# Use WORLD-based coding for spectral envelope or not
+use_world_codec: true
+
+# windows to compute delta and delta-delta features
+# set 1 to disable
+num_windows: 1
+
+# Stream-wise flags to enable/disable dynamic features
+# (mgc, lf0, vuv, bap)
+dynamic_features_flags: [False, False, False, False]
+
+# Use relative f0 modeling.
+relative_f0: false
+
+interp_unvoiced_aperiodicity: true
+
+# Vibrato mode (https://arxiv.org/abs/2108.02776)
+# 1) none -> no vibrato modeling
+#   The output features will include 4 streams: [mgc, lf0, vuv, bap]
+# 2) sine -> sine vibrato modeling.
+#   Three-dim features composed of two streams (vib params and vibrato flag) are added.
+#   The output features will include 6 streams: [mgc, lf0, vuv, bap, vib, vib_flags]
+# 3) diff -> diff-based vibrato modeling.
+#   One-dim differential F0 is added.
+#   The output features will include 5 streams: [mgc, lf0, vuv, bap, vib]
+# NOTE: you must be careful about the dimension of the acoustic features.
+# For example, if you use sine-based vibrato modeling (w/ dynamic features),
+# you'd need to increase 2*num_windows + 1 for the `out_dim` of the acoustic model.
+vibrato_mode: none
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+# Special handling for F0 smoothing
+trajectory_smoothing_f0: true
+trajectory_smoothing_cutoff_f0: 20
+
+# Correct V/UV based on the musical score.
+# This is to prevent unwanted F0 estimation failures on silence regions.
+correct_vuv: true
+
+# Correct F0 based on the musical score.
+# NOTE: it is better to manually correct f0 or adjust UST/musicxml in advance.
+correct_f0: false
+
+# NOTE: the following parameters are only used for computing mel-spectrogram
+# For 24kHz sampling rate
+fft_size: 512
+hop_size: 120
+win_length: 480
+fmin: 63
+fmax: 12000
+eps: 1e-6

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
@@ -1,0 +1,84 @@
+enabled: true
+question_path:
+wav_dir: data/acoustic/wav
+label_dir: data/acoustic/label_phone_align
+
+sample_rate: 48000
+
+# world or melf0
+feature_type: melf0
+
+# Resample type
+res_type: scipy
+
+subphone_features: coarse_coding
+
+# kiritan
+# min 174.61411571650194
+# max 659.2551138257398
+# If specified, use the values for F0 estimation.
+# Or, these are calculated from min/max notes in the musical score.
+f0_floor: null
+f0_ceil: null
+
+use_harvest: true
+d4c_threshold: 0.15
+
+frame_period: 5.333333333333333 # ms
+mgc_order: 59
+
+# Use WORLD-based coding for spectral envelope or not
+use_world_codec: true
+
+# windows to compute delta and delta-delta features
+# set 1 to disable
+num_windows: 1
+
+# Stream-wise flags to enable/disable dynamic features
+# (mgc, lf0, vuv, bap)
+dynamic_features_flags: [False, False, False, False]
+
+# Use relative f0 modeling.
+relative_f0: false
+
+interp_unvoiced_aperiodicity: true
+
+# Vibrato mode (https://arxiv.org/abs/2108.02776)
+# 1) none -> no vibrato modeling
+#   The output features will include 4 streams: [mgc, lf0, vuv, bap]
+# 2) sine -> sine vibrato modeling.
+#   Three-dim features composed of two streams (vib params and vibrato flag) are added.
+#   The output features will include 6 streams: [mgc, lf0, vuv, bap, vib, vib_flags]
+# 3) diff -> diff-based vibrato modeling.
+#   One-dim differential F0 is added.
+#   The output features will include 5 streams: [mgc, lf0, vuv, bap, vib]
+# NOTE: you must be careful about the dimension of the acoustic features.
+# For example, if you use sine-based vibrato modeling (w/ dynamic features),
+# you'd need to increase 2*num_windows + 1 for the `out_dim` of the acoustic model.
+vibrato_mode: none
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+# Special handling for F0 smoothing
+trajectory_smoothing_f0: true
+trajectory_smoothing_cutoff_f0: 20
+
+# Correct V/UV based on the musical score.
+# This is to prevent unwanted F0 estimation failures on silence regions.
+correct_vuv: true
+
+# Correct F0 based on the musical score.
+# NOTE: it is better to manually correct f0 or adjust UST/musicxml in advance.
+correct_f0: false
+
+# NOTE: the following parameters are only used for computing mel-spectrogram
+# For 24kHz sampling rate
+fft_size: 512
+hop_size: 128
+win_length: 512
+fmin: 30
+fmax: 12000
+eps: 1e-6

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
@@ -1,0 +1,75 @@
+enabled: true
+question_path:
+wav_dir: data/acoustic/wav
+label_dir: data/acoustic/label_phone_align
+
+sample_rate: 48000
+
+# world or melf0
+feature_type: world
+
+# Resample type
+res_type: scipy
+
+subphone_features: coarse_coding
+
+# kiritan
+# min 174.61411571650194
+# max 659.2551138257398
+# If specified, use the values for F0 estimation.
+# Or, these are calculated from min/max notes in the musical score.
+f0_floor: null
+f0_ceil: null
+
+use_harvest: true
+d4c_threshold: 0.15
+
+frame_period: 5 # ms
+mgc_order: 59
+
+# Use WORLD-based coding for spectral envelope or not
+use_world_codec: true
+
+# windows to compute delta and delta-delta features
+# set 1 to disable
+num_windows: 1
+
+# Stream-wise flags to enable/disable dynamic features
+# (mgc, lf0, vuv, bap)
+dynamic_features_flags: [False, False, False, False]
+
+# Use relative f0 modeling.
+relative_f0: false
+
+interp_unvoiced_aperiodicity: true
+
+# Vibrato mode (https://arxiv.org/abs/2108.02776)
+# 1) none -> no vibrato modeling
+#   The output features will include 4 streams: [mgc, lf0, vuv, bap]
+# 2) sine -> sine vibrato modeling.
+#   Three-dim features composed of two streams (vib params and vibrato flag) are added.
+#   The output features will include 6 streams: [mgc, lf0, vuv, bap, vib, vib_flags]
+# 3) diff -> diff-based vibrato modeling.
+#   One-dim differential F0 is added.
+#   The output features will include 5 streams: [mgc, lf0, vuv, bap, vib]
+# NOTE: you must be careful about the dimension of the acoustic features.
+# For example, if you use sine-based vibrato modeling (w/ dynamic features),
+# you'd need to increase 2*num_windows + 1 for the `out_dim` of the acoustic model.
+vibrato_mode: none
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+# Special handling for F0 smoothing
+trajectory_smoothing_f0: true
+trajectory_smoothing_cutoff_f0: 20
+
+# Correct V/UV based on the musical score.
+# This is to prevent unwanted F0 estimation failures on silence regions.
+correct_vuv: true
+
+# Correct F0 based on the musical score.
+# NOTE: it is better to manually correct f0 or adjust UST/musicxml in advance.
+correct_f0: false

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_diffvib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_diffvib.yaml
@@ -1,0 +1,75 @@
+enabled: true
+question_path:
+wav_dir: data/acoustic/wav
+label_dir: data/acoustic/label_phone_align
+
+sample_rate: 48000
+
+# world or melf0
+feature_type: world
+
+# Resample type
+res_type: scipy
+
+subphone_features: coarse_coding
+
+# kiritan
+# min 174.61411571650194
+# max 659.2551138257398
+# If specified, use the values for F0 estimation.
+# Or, these are calculated from min/max notes in the musical score.
+f0_floor: null
+f0_ceil: null
+
+use_harvest: true
+d4c_threshold: 0.15
+
+frame_period: 5 # ms
+mgc_order: 59
+
+# Use WORLD-based coding for spectral envelope or not
+use_world_codec: true
+
+# windows to compute delta and delta-delta features
+# set 1 to disable
+num_windows: 1
+
+# Stream-wise flags to enable/disable dynamic features
+# (mgc, lf0, vuv, bap)
+dynamic_features_flags: [False, False, False, False, False]
+
+# Use relative f0 modeling.
+relative_f0: false
+
+interp_unvoiced_aperiodicity: true
+
+# Vibrato mode (https://arxiv.org/abs/2108.02776)
+# 1) none -> no vibrato modeling
+#   The output features will include 4 streams: [mgc, lf0, vuv, bap]
+# 2) sine -> sine vibrato modeling.
+#   Three-dim features composed of two streams (vib params and vibrato flag) are added.
+#   The output features will include 6 streams: [mgc, lf0, vuv, bap, vib, vib_flags]
+# 3) diff -> diff-based vibrato modeling.
+#   One-dim differential F0 is added.
+#   The output features will include 5 streams: [mgc, lf0, vuv, bap, vib]
+# NOTE: you must be careful about the dimension of the acoustic features.
+# For example, if you use sine-based vibrato modeling (w/ dynamic features),
+# you'd need to increase 2*num_windows + 1 for the `out_dim` of the acoustic model.
+vibrato_mode: diff
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+# Special handling for F0 smoothing
+trajectory_smoothing_f0: true
+trajectory_smoothing_cutoff_f0: 20
+
+# Correct V/UV based on the musical score.
+# This is to prevent unwanted F0 estimation failures on silence regions.
+correct_vuv: true
+
+# Correct F0 based on the musical score.
+# NOTE: it is better to manually correct f0 or adjust UST/musicxml in advance.
+correct_f0: false

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_sinevib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_sinevib.yaml
@@ -1,0 +1,75 @@
+enabled: true
+question_path:
+wav_dir: data/acoustic/wav
+label_dir: data/acoustic/label_phone_align
+
+sample_rate: 48000
+
+# world or melf0
+feature_type: world
+
+# Resample type
+res_type: scipy
+
+subphone_features: coarse_coding
+
+# kiritan
+# min 174.61411571650194
+# max 659.2551138257398
+# If specified, use the values for F0 estimation.
+# Or, these are calculated from min/max notes in the musical score.
+f0_floor: null
+f0_ceil: null
+
+use_harvest: true
+d4c_threshold: 0.15
+
+frame_period: 5 # ms
+mgc_order: 59
+
+# Use WORLD-based coding for spectral envelope or not
+use_world_codec: true
+
+# windows to compute delta and delta-delta features
+# set 1 to disable
+num_windows: 1
+
+# Stream-wise flags to enable/disable dynamic features
+# (mgc, lf0, vuv, bap)
+dynamic_features_flags: [False, False, False, False, False, False]
+
+# Use relative f0 modeling.
+relative_f0: false
+
+interp_unvoiced_aperiodicity: true
+
+# Vibrato mode (https://arxiv.org/abs/2108.02776)
+# 1) none -> no vibrato modeling
+#   The output features will include 4 streams: [mgc, lf0, vuv, bap]
+# 2) sine -> sine vibrato modeling.
+#   Three-dim features composed of two streams (vib params and vibrato flag) are added.
+#   The output features will include 6 streams: [mgc, lf0, vuv, bap, vib, vib_flags]
+# 3) diff -> diff-based vibrato modeling.
+#   One-dim differential F0 is added.
+#   The output features will include 5 streams: [mgc, lf0, vuv, bap, vib]
+# NOTE: you must be careful about the dimension of the acoustic features.
+# For example, if you use sine-based vibrato modeling (w/ dynamic features),
+# you'd need to increase 2*num_windows + 1 for the `out_dim` of the acoustic model.
+vibrato_mode: sine
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+# Special handling for F0 smoothing
+trajectory_smoothing_f0: true
+trajectory_smoothing_cutoff_f0: 20
+
+# Correct V/UV based on the musical score.
+# This is to prevent unwanted F0 estimation failures on silence regions.
+correct_vuv: true
+
+# Correct F0 based on the musical score.
+# NOTE: it is better to manually correct f0 or adjust UST/musicxml in advance.
+correct_f0: false

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_static_features/acoustic
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_static_features/acoustic
@@ -1,0 +1,1 @@
+../prepare_features/acoustic

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/duration/data/myconfig.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/duration/data/myconfig.yaml
@@ -1,0 +1,34 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 8
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: 1000
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: true
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 5
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/duration/model/duration_vp_mdn.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/duration/model/duration_vp_mdn.yaml
@@ -1,0 +1,15 @@
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.VariancePredictor
+  in_dim: 82
+  out_dim: 1
+  hidden_dim: 256
+  num_layers: 5
+  kernel_size: 5
+  dropout: 0.5
+  use_mdn: true
+  num_gaussians: 4
+  init_type: "kaiming_normal"

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/duration/train/myconfig.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/duration/train/myconfig.yaml
@@ -1,0 +1,42 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: false
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 100
+checkpoint_epoch_interval: 50
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: mse
+
+stream_wise_loss: false
+use_detect_anomaly: false
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/timelag/data/myconfig.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/timelag/data/myconfig.yaml
@@ -1,0 +1,34 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 8
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: 500
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: true
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 3
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/timelag/model/timelag_vp_mdn.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/timelag/model/timelag_vp_mdn.yaml
@@ -1,0 +1,15 @@
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.VariancePredictor
+  in_dim: 82
+  out_dim: 1
+  hidden_dim: 32
+  num_layers: 3
+  kernel_size: 3
+  dropout: 0.5
+  use_mdn: true
+  num_gaussians: 4
+  init_type: "kaiming_normal"

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/timelag/train/myconfig.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train/timelag/train/myconfig.yaml
@@ -1,0 +1,42 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: false
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 100
+checkpoint_epoch_interval: 50
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: mse
+
+stream_wise_loss: false
+use_detect_anomaly: false
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/data/melf0.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/data/melf0.yaml
@@ -1,0 +1,47 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 0
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: 24000
+
+sample_rate: 48000
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: true
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null
+
+# NOTE: the following parameters must be carefully set
+# log-F0 and rest parameter indices in the input features
+# it depends on the hed file
+in_lf0_idx: 51
+in_rest_idx: 0
+# The log-F0 index in the output features
+out_lf0_idx: 80
+
+# Use world codec for spectral envelope or not
+use_world_codec: true

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/data/world.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/data/world.yaml
@@ -1,0 +1,47 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 0
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: 24000
+
+sample_rate: 48000
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: true
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null
+
+# NOTE: the following parameters must be carefully set
+# log-F0 and rest parameter indices in the input features
+# it depends on the hed file
+in_lf0_idx: 51
+in_rest_idx: 0
+# The log-F0 index in the output features
+out_lf0_idx: 60
+
+# Use world codec for spectral envelope or not
+use_world_codec: true

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_multi_ar_f0.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_multi_ar_f0.yaml
@@ -1,0 +1,95 @@
+# Separate F0 model + shared encoder + (mel, vuv) decoders
+# MDN is not used.
+
+# (mel, lf0, vuv)
+stream_sizes: [80, 1, 1]
+has_dynamic_features: [false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.MultistreamSeparateF0MelModel
+  in_dim: 86
+  out_dim: 82
+
+  stream_sizes: [80, 1, 1]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 80
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    in_dim: 86
+    out_dim: 1
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    reduction_factor: 4
+    downsample_by_conv: true
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Shared encoder
+  encoder:
+    _target_: nnsvs_contrib.acoustic_models.LSTMEncoder
+    in_dim: 86
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    hidden_dim: 512
+    out_dim: 1024
+    num_layers: 3
+    dropout: 0.0
+    bidirectional: true
+    init_type: "kaiming_normal"
+
+  # Decoders for the rest of streams
+  mel_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    out_dim: 80
+    ff_hidden_dim: 1024
+    conv_hidden_dim: 512
+    lstm_hidden_dim: 256
+    num_lstm_layers: 2
+    bidirectional: true
+    dropout: 0.1
+    init_type: "kaiming_normal"
+
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+    init_type: "kaiming_normal"

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_multi_ar_melf0_prenet0.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_multi_ar_melf0_prenet0.yaml
@@ -1,0 +1,101 @@
+# Separate F0 model + shared encoder + (mel, vuv) decoders
+# MDN is not used.
+
+# (mel, lf0, vuv)
+stream_sizes: [80, 1, 1]
+has_dynamic_features: [false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.MultistreamSeparateF0MelModel
+  in_dim: 86
+  out_dim: 82
+
+  stream_sizes: [80, 1, 1]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 80
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    in_dim: 86
+    out_dim: 1
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    reduction_factor: 4
+    downsample_by_conv: true
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Shared encoder
+  encoder:
+    _target_: nnsvs_contrib.acoustic_models.LSTMEncoder
+    in_dim: 86
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    hidden_dim: 512
+    out_dim: 1024
+    num_layers: 3
+    dropout: 0.0
+    bidirectional: true
+    init_type: "kaiming_normal"
+
+  # Decoders for the rest of streams
+  mel_model:
+    _target_: nnsvs_contrib.acoustic_models.NonAttentiveDecoder
+    in_dim: 1026
+    out_dim: 80
+    layers: 2
+    hidden_dim: 1024
+    prenet_layers: 0
+    prenet_hidden_dim: 256
+    prenet_dropout: 0.5
+    zoneout: 0.0
+    reduction_factor: 2
+    downsample_by_conv: true
+    postnet_layers: 5
+    postnet_channels: 512
+    postnet_kernel_size: 5
+    postnet_dropout: 0.0
+    init_type: "kaiming_normal"
+
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+    init_type: "kaiming_normal"

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_multi_nonar.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_multi_nonar.yaml
@@ -1,0 +1,94 @@
+# Separate F0 model + shared encoder + (mel, vuv) decoders
+# MDN is not used.
+
+# (mel, lf0, vuv)
+stream_sizes: [80, 1, 1]
+has_dynamic_features: [false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.MultistreamSeparateF0MelModel
+  in_dim: 86
+  out_dim: 82
+
+  stream_sizes: [80, 1, 1]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 80
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs.model.ResSkipF0FFConvLSTM
+    in_dim: 86
+    out_dim: 1
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    dropout: 0.1
+    num_lstm_layers: 2
+    bidirectional: true
+    init_type: "kaiming_normal"
+    # Last MDN layer (disabled by default)
+    use_mdn: false
+    num_gaussians: 8
+    dim_wise: true
+    # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+    # otherwise the model does't work at all
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    # Please leave the following parameters unspecified if you want to
+    # find the corresponding values automatically from in/out scalers.
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Shared encoder
+  encoder:
+    _target_: nnsvs_contrib.acoustic_models.LSTMEncoder
+    in_dim: 86
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    hidden_dim: 512
+    out_dim: 1024
+    num_layers: 3
+    dropout: 0.0
+    bidirectional: true
+    init_type: "kaiming_normal"
+
+  # Decoders for the rest of streams
+  mel_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    out_dim: 80
+    ff_hidden_dim: 1024
+    conv_hidden_dim: 512
+    lstm_hidden_dim: 256
+    num_lstm_layers: 2
+    bidirectional: true
+    dropout: 0.1
+    init_type: "kaiming_normal"
+
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+    init_type: "kaiming_normal"

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_single_ar.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_melf0_single_ar.yaml
@@ -1,0 +1,40 @@
+# (mel, lf0, vuv)
+stream_sizes: [80, 1, 1]
+has_dynamic_features: [false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+  in_dim: 86
+  out_dim: 82
+  in_ph_start_idx: 3
+  in_ph_end_idx: 50
+  embed_dim: 256
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  decoder_layers: 2
+  decoder_hidden_dim: 1024
+  prenet_layers: 0
+  prenet_hidden_dim: 256
+  prenet_dropout: 0.5
+  zoneout: 0.0
+  reduction_factor: 2
+  downsample_by_conv: true
+  scaled_tanh: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 80
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_f0.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_f0.yaml
@@ -1,0 +1,104 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.MultistreamSeparateF0ParametricModel
+  in_dim: 86
+  out_dim: 65
+
+  stream_sizes: [60, 1, 1, 3]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    in_dim: 86
+    out_dim: 1
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    reduction_factor: 4
+    downsample_by_conv: true
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Shared encoder
+  encoder:
+    _target_: nnsvs_contrib.acoustic_models.LSTMEncoder
+    in_dim: 86
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    hidden_dim: 512
+    out_dim: 1024
+    num_layers: 3
+    dropout: 0.0
+    bidirectional: true
+    init_type: "kaiming_normal"
+
+  # Decoders for the rest of streams
+  mgc_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 1024
+    conv_hidden_dim: 512
+    lstm_hidden_dim: 256
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 60
+    dropout: 0.1
+
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+
+  bap_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 62
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 3
+    dropout: 0.0
+
+  vib_model: null
+  vib_flags_model: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0_prenet0.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0_prenet0.yaml
@@ -1,0 +1,113 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.MultistreamSeparateF0ParametricModel
+  in_dim: 86
+  out_dim: 65
+
+  stream_sizes: [60, 1, 1, 3]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    in_dim: 86
+    out_dim: 1
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    reduction_factor: 4
+    downsample_by_conv: true
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Shared encoder
+  encoder:
+    _target_: nnsvs_contrib.acoustic_models.LSTMEncoder
+    in_dim: 86
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    hidden_dim: 512
+    out_dim: 1024
+    num_layers: 3
+    dropout: 0.0
+    bidirectional: true
+    init_type: "kaiming_normal"
+
+  # Decoders for the rest of streams
+  mgc_model:
+    _target_: nnsvs_contrib.acoustic_models.NonAttentiveDecoder
+    in_dim: 1026
+    out_dim: 60
+    layers: 2
+    hidden_dim: 1024
+    prenet_layers: 0
+    prenet_hidden_dim: 192
+    prenet_dropout: 0.5
+    zoneout: 0.0
+    reduction_factor: 2
+    downsample_by_conv: true
+    postnet_layers: 5
+    postnet_channels: 512
+    postnet_kernel_size: 5
+    postnet_dropout: 0.0
+    init_type: "kaiming_normal"
+
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+    init_type: "kaiming_normal"
+
+  bap_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 62
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 3
+    dropout: 0.0
+    init_type: "kaiming_normal"
+
+  vib_model: null
+  vib_flags_model: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap.yaml
@@ -1,0 +1,116 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.MultistreamSeparateF0ParametricModel
+  in_dim: 86
+  out_dim: 65
+
+  stream_sizes: [60, 1, 1, 3]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    in_dim: 86
+    out_dim: 1
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    reduction_factor: 4
+    downsample_by_conv: true
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Shared encoder
+  encoder:
+    _target_: nnsvs_contrib.acoustic_models.LSTMEncoder
+    in_dim: 86
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    hidden_dim: 512
+    out_dim: 1024
+    num_layers: 3
+    dropout: 0.0
+    bidirectional: true
+    init_type: "kaiming_normal"
+
+  # Decoders for the rest of streams
+  mgc_model:
+    _target_: nnsvs_contrib.acoustic_models.NonAttentiveDecoder
+    in_dim: 1026
+    out_dim: 60
+    layers: 2
+    hidden_dim: 1024
+    prenet_layers: 2
+    prenet_hidden_dim: 192
+    prenet_dropout: 0.5
+    zoneout: 0.0
+    reduction_factor: 2
+    downsample_by_conv: true
+    postnet_layers: 5
+    postnet_channels: 512
+    postnet_kernel_size: 5
+    postnet_dropout: 0.0
+
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+
+  bap_model:
+    _target_: nnsvs_contrib.acoustic_models.NonAttentiveDecoder
+    in_dim: 1026
+    out_dim: 3
+    layers: 2
+    hidden_dim: 256
+    prenet_layers: 2
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    zoneout: 0.0
+    reduction_factor: 2
+    downsample_by_conv: true
+    postnet_layers: 5
+    postnet_channels: 64
+    postnet_kernel_size: 5
+    postnet_dropout: 0.0
+
+  vib_model: null
+  vib_flags_model: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1.yaml
@@ -1,0 +1,123 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.NPSSMultistreamParametricModel
+  in_dim: 86
+  out_dim: 65
+
+  stream_sizes: [60, 1, 1, 3]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  npss_style_conditioning: false
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    in_dim: 86
+    out_dim: 1
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    reduction_factor: 4
+    downsample_by_conv: true
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Spectral parameter prediction model
+  mgc_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMNonAttentiveDecoder
+    in_dim: 87 # (x, lf0)
+    out_dim: 60
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 1024
+    conv_hidden_dim: 512
+    lstm_hidden_dim: 256
+    num_lstm_layers: 3
+    decoder_layers: 2
+    decoder_hidden_dim: 1024
+    prenet_layers: 0
+    prenet_hidden_dim: 192
+    prenet_dropout: 0.5
+    zoneout: 0.0
+    reduction_factor: 2
+    downsample_by_conv: true
+    postnet_layers: 5
+    postnet_channels: 512
+    postnet_kernel_size: 5
+    postnet_dropout: 0.0
+    init_type: "kaiming_normal"
+
+  # Aperiodic parameter prediction model
+  bap_model:
+    _target_: nnsvs_contrib.acoustic_models.BiLSTMNonAttentiveDecoder
+    in_dim: 87 # (x, lf0)
+    out_dim: 3
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 1024
+    conv_hidden_dim: 512
+    lstm_hidden_dim: 256
+    num_lstm_layers: 3
+    decoder_layers: 2
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 192
+    prenet_dropout: 0.5
+    zoneout: 0.0
+    reduction_factor: 2
+    downsample_by_conv: true
+    postnet_layers: 5
+    postnet_channels: 512
+    postnet_kernel_size: 5
+    postnet_dropout: 0.0
+    init_type: "kaiming_normal"
+
+  # V/UV prediction model
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 90 # (x, lf0, bap)
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+    init_type: "kaiming_normal"

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_nonar.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_multi_nonar.yaml
@@ -1,0 +1,103 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.MultistreamSeparateF0ParametricModel
+  in_dim: 86
+  out_dim: 65
+
+  stream_sizes: [60, 1, 1, 3]
+  reduction_factor: 4
+
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_rest_idx: 0
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs.model.ResSkipF0FFConvLSTM
+    in_dim: 86
+    out_dim: 1
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    dropout: 0.1
+    num_lstm_layers: 2
+    bidirectional: true
+    init_type: "kaiming_normal"
+    # Last MDN layer (disabled by default)
+    use_mdn: false
+    num_gaussians: 8
+    dim_wise: true
+    # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+    # otherwise the model does't work at all
+    in_lf0_idx: 51
+    out_lf0_idx: 0
+    # Please leave the following parameters unspecified if you want to
+    # find the corresponding values automatically from in/out scalers.
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Shared encoder
+  encoder:
+    _target_: nnsvs_contrib.acoustic_models.LSTMEncoder
+    in_dim: 86
+    in_ph_start_idx: 3
+    in_ph_end_idx: 50
+    embed_dim: 256
+    hidden_dim: 512
+    out_dim: 1024
+    num_layers: 3
+    dropout: 0.0
+    bidirectional: true
+    init_type: "kaiming_normal"
+
+  # Decoders for the rest of streams
+  mgc_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 1024
+    conv_hidden_dim: 512
+    lstm_hidden_dim: 256
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 60
+    dropout: 0.1
+
+  vuv_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+
+  bap_model:
+    _target_: nnsvs_contrib.acoustic_models.FFConvLSTM
+    in_dim: 1026
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 62
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 3
+    dropout: 0.0
+
+  vib_model: null
+  vib_flags_model: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_single_ar.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_nnsvs_world_single_ar.yaml
@@ -1,0 +1,40 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs_contrib.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+  in_dim: 86
+  out_dim: 65
+  in_ph_start_idx: 3
+  in_ph_end_idx: 50
+  embed_dim: 256
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  decoder_layers: 2
+  decoder_hidden_dim: 1024
+  prenet_layers: 0
+  prenet_hidden_dim: 192
+  prenet_dropout: 0.5
+  zoneout: 0.0
+  reduction_factor: 2
+  downsample_by_conv: true
+  scaled_tanh: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_diffvib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_diffvib.yaml
@@ -1,0 +1,31 @@
+# (mgc, lf0, vuv, bap, vib)
+stream_sizes: [60, 1, 1, 3, 1]
+has_dynamic_features: [false, false, false, false, False]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.ResSkipF0FFConvLSTM
+  in_dim: 86
+  out_dim: 66
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  bidirectional: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  dim_wise: true
+  init_type: "kaiming_normal"
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_diffvib_pitchreg.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_diffvib_pitchreg.yaml
@@ -1,0 +1,31 @@
+# (mgc, lf0, vuv, bap, vib)
+stream_sizes: [60, 1, 1, 3, 1]
+has_dynamic_features: [false, false, false, false, False]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.ResSkipF0FFConvLSTM
+  in_dim: 86
+  out_dim: 66
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  bidirectional: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  dim_wise: true
+  init_type: "kaiming_normal"
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_novib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_novib.yaml
@@ -1,0 +1,31 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.ResSkipF0FFConvLSTM
+  in_dim: 86
+  out_dim: 65
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  bidirectional: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  dim_wise: true
+  init_type: "kaiming_normal"
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_novib_pitchreg.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_novib_pitchreg.yaml
@@ -1,0 +1,31 @@
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 3]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.ResSkipF0FFConvLSTM
+  in_dim: 86
+  out_dim: 65
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  bidirectional: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  dim_wise: true
+  init_type: "kaiming_normal"
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_sinevib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_sinevib.yaml
@@ -1,0 +1,31 @@
+# (mgc, lf0, vuv, bap, vib, vib_flags)
+stream_sizes: [60, 1, 1, 3, 2, 1]
+has_dynamic_features: [false, false, false, false, False, False]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.ResSkipF0FFConvLSTM
+  in_dim: 86
+  out_dim: 68
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  bidirectional: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  dim_wise: true
+  init_type: "kaiming_normal"
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_sinevib_pitchreg.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/model/acoustic_sinsy_world_sinevib_pitchreg.yaml
@@ -1,0 +1,31 @@
+# (mgc, lf0, vuv, bap, vib, vib_flags)
+stream_sizes: [60, 1, 1, 3, 2, 1]
+has_dynamic_features: [false, false, false, false, False, False]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.model.ResSkipF0FFConvLSTM
+  in_dim: 86
+  out_dim: 68
+  ff_hidden_dim: 2048
+  conv_hidden_dim: 1024
+  lstm_hidden_dim: 256
+  dropout: 0.0
+  num_lstm_layers: 2
+  bidirectional: true
+  # Last MDN layer (disabled by default)
+  use_mdn: false
+  num_gaussians: 1
+  dim_wise: true
+  init_type: "kaiming_normal"
+  # NOTE: you MUST set in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all
+  in_lf0_idx: 51
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/train/myconfig.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/train/myconfig.yaml
@@ -1,0 +1,59 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: true
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# PWG checkpoint for synthesizing waveforms
+pretrained_vocoder_checkpoint: null
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 100
+checkpoint_epoch_interval: 20
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: l1
+
+# Weight for pitch regularization loss
+# If > 0.0, add a pitch regularization loss that biases the model to
+# predict closer F0 to the F0 derived from the musical score.
+# This is conceptually same as imposing a prior distribution of the residual F0
+# to be N(0, sigma) (if we use L2 loss)
+# https://arxiv.org/abs/2108.02776
+pitch_reg_weight: 0.0
+
+# decay_size * 0.005 sec. decay to compute pitch reg weights
+pitch_reg_decay_size: 60
+
+max_num_eval_utts: 10
+
+stream_wise_loss: false
+use_detect_anomaly: false
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.0001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+  clip_norm: 1.0
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/train/pitchreg.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/train_acoustic/train/pitchreg.yaml
@@ -1,0 +1,59 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: true
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# PWG checkpoint for synthesizing waveforms
+pretrained_vocoder_checkpoint: null
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 100
+checkpoint_epoch_interval: 20
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: l1
+
+# Weight for pitch regularization loss
+# If > 0.0, add a pitch regularization loss that biases the model to
+# predict closer F0 to the F0 derived from the musical score.
+# This is conceptually same as imposing a prior distribution of the residual F0
+# to be N(0, sigma) (if we use L2 loss)
+# https://arxiv.org/abs/2108.02776
+pitch_reg_weight: 0.5
+
+# decay_size * 0.005 sec. decay to compute pitch reg weights
+pitch_reg_decay_size: 60
+
+max_num_eval_utts: 10
+
+stream_wise_loss: false
+use_detect_anomaly: false
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.0001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+  clip_norm: 1.0
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/config.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/config.yaml
@@ -1,0 +1,139 @@
+### General settings.
+## The name of singer
+spk: "namine_ritsu"
+
+## exp tag(for managing experiments)
+tag:
+
+## Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: "~/data/「波音リツ」歌声データベースVer2"
+
+## Output directory
+# All the generated labels, intermediate files, and segmented wav files
+# will be saved in the following directory
+out_dir: "./data"
+
+## Songs to be excluded from training.
+exclude_songs: []
+
+### Utaupy related settings.
+## Utaupy table path
+# This singing voice database contains the unvoiced vowels "I" and "U".
+# To enable the unvoiced vowels, modified version of sinsy dictionary files
+# are needed.
+utaupy_table_path: "../../_common/no2/utaupy/kana2phonemes_002_oto2lab.table"
+
+## HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/jp_icassp2023.hed"
+
+### Data preparation related settings.
+## Song segmentation by silence durations.
+# Split song by silences (in sec)
+segmentation_threshold: 0.1
+# Min duration for a segment
+# note: there could be some exceptions (e.g., the last segment of a song)
+segment_min_duration: 5.0
+# Force split segments if long silence is found regardless of min_duration
+force_split_threshold: 5.0
+# Offset correction
+# If True, offset is computed in an entire song
+# otherwise offset is computed for each segment
+global_offset_correction: False
+offset_correction_threshold: 0.01
+# Time-lag constraints to filter outliers
+timelag_allowed_range: [-20, 19]
+timelag_allowed_range_rest: [-40, 39]
+
+suppress_start_end_pau: True
+start_end_pau_suppression_ratio: 0.2
+
+# Audio sampling rate
+# CAUTION: Changing sample_rate may affect the dimension number of acoustic features.
+# DO NOT CHANGE this unless you know the relationship between the dim of bap and sample_rate.
+sample_rate: 24000
+
+gain_normalize: False
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: nnsvs_contrib_static_only
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_vp_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_vp_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_nnsvs_ar
+acoustic_train: myconfig
+acoustic_data: world
+
+postfilter_model: postfilter_mgc
+postfilter_train: mgc
+postfilter_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+# Advanced settings for hyperparameter search with Hydra and Optuna.
+# https://hydra.cc/docs/plugins/optuna_sweeper/
+# NOTE: Don't use spaces for each search space configuration.
+# OK: data.batch_size=range(1,16)
+# NG: data.batch_size=range(1, 16)
+# Example 1: data.batch_size=range(1,16) model.netG.hidden_dim=choice(32,64,128)
+# Example 2: train.optim.optimizer.params.lr=interval(0.0001,0.01)
+timelag_hydra_optuna_sweeper_args:
+timelag_hydra_optuna_sweeper_n_trials: 100
+duration_hydra_optuna_sweeper_args:
+duration_hydra_optuna_sweeper_n_trials: 100
+acoustic_hydra_optuna_sweeper_args:
+acoustic_hydra_optuna_sweeper_n_trials: 100
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+# conf/synthesis/synthesis/${synthesis}
+synthesis: world_gv
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth
+postfilter_eval_checkpoint: latest.pth
+
+###########################################################
+#                VOCODER SETTING                          #
+###########################################################
+
+# NOTE: conf/parallel_wavegan/${vocoder_model}.yaml must exist.
+vocoder_model:
+# Pretrained checkpoint path for the vocoder model
+# NOTE: if you want to try fine-tuning, please specify the path here
+pretrained_vocoder_checkpoint:
+# absolute/relative path to the checkpoint
+# NOTE: the checkpoint is used for synthesis and packing
+# This doesn't have any effect on training
+vocoder_eval_checkpoint:

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/run.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/run.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+function xrun () {
+    set -x
+    $@
+    set +x
+}
+
+script_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
+NNSVS_ROOT=$script_dir/../../../
+NNSVS_COMMON_ROOT=$NNSVS_ROOT/recipes/_common/spsvs
+NO2_ROOT=$NNSVS_ROOT/recipes/_common/no2
+. $NNSVS_ROOT/utils/yaml_parser.sh || exit 1;
+
+eval $(parse_yaml "./config.yaml" "")
+
+train_set="train_no_dev"
+dev_set="dev"
+eval_set="eval"
+datasets=($train_set $dev_set $eval_set)
+testsets=($dev_set $eval_set)
+
+dumpdir=dump
+dump_org_dir=$dumpdir/$spk/org
+dump_norm_dir=$dumpdir/$spk/norm
+
+stage=0
+stop_stage=0
+
+. $NNSVS_ROOT/utils/parse_options.sh || exit 1;
+
+# exp name
+if [ -z ${tag:=} ]; then
+    expname=${spk}
+else
+    expname=${spk}_${tag}
+fi
+expdir=exp/$expname
+
+if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
+    if [ ! -e $db_root ]; then
+	cat<<EOF
+stage -1: Downloading
+
+This recipe does not download the archive of singing voice database automatically to
+provide you the opportunity to read the original license.
+
+Please visit https://drive.google.com/drive/folders/1XA2cm3UyRpAk_BJb1LTytOWrhjsZKbSN
+and read the term of services, and then download the singing voice database manually.
+EOF
+    fi
+fi
+
+if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
+    echo "stage 0: Data preparation"
+    sh $NO2_ROOT/utils/data_prep.sh ./config.yaml ust
+    mkdir -p data/list
+
+    echo "train/dev/eval split"
+    # NOTE: 110 songs in total
+    find data/acoustic/ -type f -name "*.wav" -exec basename {} .wav \; \
+	 | sort > data/list/utt_list.txt
+    # # 5 songs for dev/eval
+    grep -e 1st_color -e ARROW -e BC -e Closetoyou -e ERROR data/list/utt_list.txt > data/list/$eval_set.list
+    grep -e Baptism -e COZMIC_HEART -e Choir -e BRD -e Creuzer data/list/utt_list.txt > data/list/$dev_set.list
+    grep -v -e 1st_color -e ERROR -e ARROW -e BC -e Closetoyou -e Baptism -e COZMIC_HEART -e Choir -e BRD -e Creuzer data/list/utt_list.txt > data/list/$train_set.list
+fi
+
+# Run the rest of the steps
+# Please check the script file for more details
+. $NNSVS_COMMON_ROOT/run_common_steps_dev.sh
+
+if [ ${stage} -le 100 ] && [ ${stop_stage} -ge 100 ]; then
+    . synthesis_icassp2023.sh
+fi
+
+if [ ${stage} -le 101 ] && [ ${stop_stage} -ge 101 ]; then
+    . anasyn_icassp2023.sh
+fi

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/synthesis_icassp2023.sh
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/synthesis_icassp2023.sh
@@ -1,0 +1,68 @@
+# NOTE: the script is supposed to be used called from nnsvs recipes.
+# Please don't try to run the shell script directory.
+
+if [ -d conf/synthesis ]; then
+    ext="--config-dir conf/synthesis"
+else
+    ext=""
+fi
+
+if [ -z $timelag_eval_checkpoint ]; then
+    timelag_eval_checkpoint=best_loss.pth
+fi
+if [ -z $duration_eval_checkpoint ]; then
+    duration_eval_checkpoint=best_loss.pth
+fi
+if [ -z $acoustic_eval_checkpoint ]; then
+    acoustic_eval_checkpoint=latest.pth
+fi
+
+if [ -z "${vocoder_eval_checkpoint}" ]; then
+    if [ ! -z "${vocoder_model}" ]; then
+        vocoder_eval_checkpoint="$(ls -dt "${expdir}/${vocoder_model}"/*.pkl | head -1 || true)"
+    fi
+fi
+
+if [ -z "${vocoder_eval_checkpoint}" ]; then
+    dst_name=synthesis_${timelag_model}_${duration_model}_${acoustic_model}_world
+else
+    if [ ! -z "${vocoder_model}" ]; then
+        dst_name=synthesis_${acoustic_model}_${vocoder_model}
+    else
+        vocoder_name=$(dirname ${vocoder_eval_checkpoint})
+        vocoder_name=$(basename $vocoder_name)
+        dst_name=synthesis_${acoustic_model}_${vocoder_name}
+    fi
+fi
+
+for s in ${testsets[@]}; do
+    for input in label_phone_score; do
+        if [ $input = label_phone_score ]; then
+            ground_truth_duration=false
+        else
+            ground_truth_duration=true
+        fi
+
+        xrun python $NNSVS_ROOT/nnsvs_contrib/bin/synthesis.py $ext \
+            synthesis=$synthesis \
+            synthesis.sample_rate=$sample_rate \
+            synthesis.qst=$question_path \
+            synthesis.ground_truth_duration=$ground_truth_duration \
+            timelag.checkpoint=$expdir/${timelag_model}/$timelag_eval_checkpoint \
+            timelag.in_scaler_path=$dump_norm_dir/in_timelag_scaler.joblib \
+            timelag.out_scaler_path=$dump_norm_dir/out_timelag_scaler.joblib \
+            timelag.model_yaml=$expdir/${timelag_model}/model.yaml \
+            duration.checkpoint=$expdir/${duration_model}/$duration_eval_checkpoint \
+            duration.in_scaler_path=$dump_norm_dir/in_duration_scaler.joblib \
+            duration.out_scaler_path=$dump_norm_dir/out_duration_scaler.joblib \
+            duration.model_yaml=$expdir/${duration_model}/model.yaml \
+            acoustic.checkpoint=$expdir/${acoustic_model}/$acoustic_eval_checkpoint \
+            acoustic.in_scaler_path=$dump_norm_dir/in_acoustic_scaler.joblib \
+            acoustic.out_scaler_path=$dump_norm_dir/out_acoustic_scaler.joblib \
+            acoustic.model_yaml=$expdir/${acoustic_model}/model.yaml \
+            vocoder.checkpoint=$vocoder_eval_checkpoint \
+            utt_list=./data/list/$s.list \
+            in_dir=data/acoustic/$input/ \
+            out_dir=$expdir/$dst_name/$s/
+    done
+done


### PR DESCRIPTION
Please check recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/README.md. I will copy-and-paste the contents to the PR description.

Ref #150 

# Notes for reproducing experiments

Paper: https://arxiv.org/abs/2210.15987.

## Data

Please normalize data to -26dB before running recipes. You can use sv56 to normalize audio signals.

## Recipes

- `icassp2023-24k-world`: Recipe using WORLD features. NNSVS-WORLD v1, v2, v3, v4, and Sinsy without vibrato modeling were trained with this recipe.
- `icassp2023-24k-mel`: Recipe using mel-spectrogram. NNSVS-Mel v1, v2, and v3 were trained with this recipe.
- `icassp2023-24k-mel-diffsinger-compat`: Recipe using mel-spectrogram. The feature extraction settings (e.g. FFT size) are the same as the [DiffSinger](https://github.com/MoonInTheRiver/DiffSinger). This recipe was used for training DiffSinger-compatible hn-HiFi-GAN.
- `icassp2023-24k-world-sinevib`: Recipe using WORLD features with extra sine-based vibrato parameters. This recipe was used to build Sinsy with explicit vibrato modeling.
- `icassp2023-24k-world-diffvib`: Recipe using WORLD features with extra diff-based vibrato parameters. We used this recipe only in our preliminary experiments.

## Acoustic model configs

The following table summarizes the names of acoustic model configurations used in our experiments.
All the config files are stored inside the recipe directories.

| System                      | Recipe                       | Acoustic model config                               |
|-----------------------------|------------------------------|-----------------------------------------------------|
| Sinsy                       | icassp2023-24k-world         | acoustic_sinsy_world_novib.yaml                     |
| Sinsy (w/ pitch correction) | icassp2023-24k-world         | acoustic_sinsy_world_novib_pitchreg.yaml            |
| Sinsy (w/ vibrato modeling) | icassp2023-24k-world-sinevib | acoustic_sinsy_world_sinevib_pitchreg.yaml          |
| NNSVS-Mel v1                | icassp2023-24k-mel           | acoustic_nnsvs_melf0_multi_nonar.yaml               |
| NNSVS-Mel v2                | icassp2023-24k-mel           | acoustic_nnsvs_melf0_multi_ar_f0.yaml               |
| NNSVS-Mel v3                | icassp2023-24k-mel           | acoustic_nnsvs_melf0_multi_ar_melf0_prenet0.yaml    |
| NNSVS-WORLD v1              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_nonar.yaml               |
| NNSVS-WORLD v2              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_ar_f0.yaml               |
| NNSVS-WORLD v3              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_ar_mgcf0_prenet0.yaml    |
| NNSVS-WORLD v4              | icassp2023-24k-world         | acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1.yaml |


## How to run recipes

The same as the other recipes.

## Run acoustic model training

For example, to train NNSVS-WORLD v4, you can try the following command:

```
CUDA_VISIBLE_DEVICES=0 ./run.sh  --stage 4 --stop-stage 4 --tag 20220926_icassp_v3 --acoustic-model acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1 --acoustic-data myconfig
```

If you have a pre-trained uSFGAN model checkpoint, you could try:

```
CUDA_VISIBLE_DEVICES=0 ./run.sh  --stage 4 --stop-stage 4 --tag 20220926_icassp_v3 --acoustic-model acoustic_nnsvs_world_multi_ar_mgcf0bap_npss_v1 --acoustic-data myconfig  --vocoder-eval-checkpoint $PWD/path/to/usfgan/checkpoint-600000steps.pkl
```

The above two commands are based on my command line history.

## How to train uSFGAN vocoder

TBD
