### PR TITLE
Replace duplicated use_harvest option by f0_extractor

### DIFF
--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
@@ -21,7 +21,7 @@ subphone_features: coarse_coding
 f0_floor: null
 f0_ceil: null
 
-use_harvest: true
+f0_extractor: harvest
 d4c_threshold: 0.15
 
 frame_period: 5 # ms

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
@@ -21,7 +21,7 @@ subphone_features: coarse_coding
 f0_floor: null
 f0_ceil: null
 
-use_harvest: true
+f0_extractor: harvest
 d4c_threshold: 0.15
 
 frame_period: 5.333333333333333 # ms

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
@@ -21,7 +21,7 @@ subphone_features: coarse_coding
 f0_floor: null
 f0_ceil: null
 
-use_harvest: true
+f0_extractor: harvest
 d4c_threshold: 0.15
 
 frame_period: 5 # ms

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_diffvib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_diffvib.yaml
@@ -21,7 +21,7 @@ subphone_features: coarse_coding
 f0_floor: null
 f0_ceil: null
 
-use_harvest: true
+f0_extractor: harvest
 d4c_threshold: 0.15
 
 frame_period: 5 # ms

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_sinevib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_sinevib.yaml
@@ -21,7 +21,7 @@ subphone_features: coarse_coding
 f0_floor: null
 f0_ceil: null
 
-use_harvest: true
+f0_extractor: harvest
 d4c_threshold: 0.15
 
 frame_period: 5 # ms


### PR DESCRIPTION
Hello, 

It seems that use_harvest option was replaced by f0_extractor since the commit 25b14a77ad9ad255d622187a5f96f207ffd79a33, but the newest recipes of namine_ritsu_utagoe_db still make use of use_harvest option.  This PR will fix it.