### PR TITLE
Add support for mcep-based aperiodicity parametrization

### DIFF
--- a/nnsvs/bin/conf/prepare_features/acoustic/melf0_48k.yaml
+++ b/nnsvs/bin/conf/prepare_features/acoustic/melf0_48k.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/nnsvs/bin/conf/prepare_features/acoustic/static_deltadelta.yaml
+++ b/nnsvs/bin/conf/prepare_features/acoustic/static_deltadelta.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 3

--- a/nnsvs/bin/conf/prepare_features/acoustic/static_only.yaml
+++ b/nnsvs/bin/conf/prepare_features/acoustic/static_only.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/nnsvs/bin/prepare_features.py
+++ b/nnsvs/bin/prepare_features.py
@@ -176,6 +176,8 @@ def my_app(config: DictConfig) -> None:
             dynamic_features_flags=config.acoustic.dynamic_features_flags,
             use_world_codec=config.acoustic.use_world_codec,
             res_type=config.acoustic.res_type,
+            use_mcep_aperiodicity=config.acoustic.use_mcep_aperiodicity,
+            mcep_aperiodicity_order=config.acoustic.mcep_aperiodicity_order,
         )
     elif config.acoustic.feature_type == "melf0":
         out_acoustic_source = MelF0AcousticSource(

--- a/nnsvs/bin/prepare_voc_features.py
+++ b/nnsvs/bin/prepare_voc_features.py
@@ -75,6 +75,8 @@ def my_app(config: DictConfig) -> None:
             config.acoustic.mgc_order,
             config.acoustic.num_windows,
             config.acoustic.vibrato_mode,
+            use_mcep_aperiodicity=config.acoustic.use_mcep_aperiodicity,
+            mcep_aperiodicity_order=config.acoustic.mcep_aperiodicity_order,
         )
     elif config.acoustic.feature_type == "melf0":
         stream_sizes = [80, 1, 1]

--- a/nnsvs/util.py
+++ b/nnsvs/util.py
@@ -55,7 +55,12 @@ def init_weights(net, init_type="normal", init_gain=0.02):
 
 
 def get_world_stream_info(
-    sr: int, mgc_order: int, num_windows: int = 3, vibrato_mode: str = "none"
+    sr: int,
+    mgc_order: int,
+    num_windows: int = 3,
+    vibrato_mode: str = "none",
+    use_mcep_aperiodicity: bool = False,
+    mcep_aperiodicity_order: int = 24,
 ):
     """Get stream sizes for WORLD-based acoustic features
 
@@ -73,7 +78,9 @@ def get_world_stream_info(
         (mgc_order + 1) * num_windows,
         num_windows,
         1,
-        pyworld.get_num_aperiodicities(sr) * num_windows,
+        pyworld.get_num_aperiodicities(sr) * num_windows
+        if not use_mcep_aperiodicity
+        else mcep_aperiodicity_order + 1,
     ]
     if vibrato_mode == "diff":
         # vib

--- a/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_melf0_48k.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_melf0_48k.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_static_deltadelta.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_static_deltadelta.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 3

--- a/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_static_only_correct_f0.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/prepare_features/acoustic/nnsvs_contrib_static_only_correct_f0.yaml
@@ -31,6 +31,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/_common/scaler_joblib2npy_voc.py
+++ b/recipes/_common/scaler_joblib2npy_voc.py
@@ -22,6 +22,17 @@ def get_parser():
     parser.add_argument("--mgc_order", type=int, default=59, help="mgc order")
     parser.add_argument("--num_windows", type=int, default=3, help="number of windows")
     parser.add_argument("--vibrato_mode", type=str, default="none", help="vibrato mode")
+    parser.add_argument(
+        "--use_mcep_aperiodicity",
+        action="store_true",
+        help="use mcep-based aperiodicity",
+    )
+    parser.add_argument(
+        "--mcep_aperiodicity_order",
+        type=int,
+        default=24,
+        help="order of mcep-based aperiodicity",
+    )
 
     return parser
 
@@ -51,7 +62,12 @@ if __name__ == "__main__":
         stream_sizes = [80, 1, 1]
     else:
         stream_sizes = get_world_stream_info(
-            args.sample_rate, args.mgc_order, args.num_windows, args.vibrato_mode
+            args.sample_rate,
+            args.mgc_order,
+            args.num_windows,
+            args.vibrato_mode,
+            use_mcep_aperiodicity=args.use_mcep_aperiodicity,
+            mcep_aperiodicity_order=args.mcep_aperiodicity_order,
         )
     has_dynamic_features = [False] * len(stream_sizes)
 

--- a/recipes/_common/spsvs/prepare_voc_features.sh
+++ b/recipes/_common/spsvs/prepare_voc_features.sh
@@ -31,6 +31,29 @@ else
     ext=""
 fi
 
+local_config_path=conf/prepare_static_features/acoustic/${acoustic_features}.yaml
+global_config_path=$NNSVS_ROOT/nnsvs/bin/conf/prepare_static_features/acoustic/${acoustic_features}.yaml
+if [ -e $local_config_path ]; then
+    mgc_order=$(grep mgc_order $local_config_path | awk '{print $2}')
+    use_mcep_aperiodicity=$(grep use_mcep_aperiodicity $local_config_path | awk '{print $2}')
+    mcep_aperiodicity_order=$(grep mcep_aperiodicity_order $local_config_path | awk '{print $2}')
+    ext="$ext --mgc_order $mgc_order --mcep_aperiodicity_order $mcep_aperiodicity_order"
+    if [ $use_mcep_aperiodicity == "true" ]; then
+        ext="$ext --use_mcep_aperiodicity"
+    fi
+elif [ -e $global_config_path ]; then
+    mgc_order=$(grep mgc_order $global_config_path | awk '{print $2}')
+    use_mcep_aperiodicity=$(grep use_mcep_aperiodicity $global_config_path | awk '{print $2}')
+    mcep_aperiodicity_order=$(grep mcep_aperiodicity_order $global_config_path | awk '{print $2}')
+    ext="$ext --mgc_order $mgc_order --mcep_aperiodicity_order $mcep_aperiodicity_order"
+    if [ $use_mcep_aperiodicity == "true" ]; then
+        ext="$ext --use_mcep_aperiodicity"
+    fi
+else
+    echo "config file not found: $local_config_path or $global_config_path"
+    exit 1
+fi
+
 # Compute statistics of vocoder's input features
 # NOTE: no-op if the acoustic features don't have dynamic features
 xrun python $NNSVS_COMMON_ROOT/scaler_joblib2npy_voc.py \

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k.yaml
@@ -30,6 +30,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_melf0_24k_diffsinger_compat.yaml
@@ -30,6 +30,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only.yaml
@@ -30,6 +30,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_diffvib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_diffvib.yaml
@@ -30,6 +30,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_sinevib.yaml
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/conf/prepare_features/acoustic/nnsvs_contrib_static_only_sinevib.yaml
@@ -30,6 +30,10 @@ mgc_order: 59
 # Use WORLD-based coding for spectral envelope or not
 use_world_codec: true
 
+# Use mcep-based aperidicity paramatrization
+use_mcep_aperiodicity: false
+mcep_aperiodicity_order: 24
+
 # windows to compute delta and delta-delta features
 # set 1 to disable
 num_windows: 1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,3 +15,28 @@ def test_get_world_stream_info():
 
     assert get_world_stream_info(44100, 59, 1, vibrato_mode="none") == [60, 1, 1, 5]
     assert get_world_stream_info(48000, 59, 1, vibrato_mode="none") == [60, 1, 1, 5]
+
+
+def test_get_world_stream_info_mcep_aperiodicity():
+    assert (
+        get_world_stream_info(
+            44100,
+            59,
+            1,
+            vibrato_mode="none",
+            use_mcep_aperiodicity=True,
+            mcep_aperiodicity_order=24,
+        )
+        == [60, 1, 1, 25]
+    )
+    assert (
+        get_world_stream_info(
+            48000,
+            59,
+            1,
+            vibrato_mode="none",
+            use_mcep_aperiodicity=True,
+            mcep_aperiodicity_order=24,
+        )
+        == [60, 1, 1, 25]
+    )

--- a/utils/nnsvs2usfgan.py
+++ b/utils/nnsvs2usfgan.py
@@ -87,12 +87,20 @@ if __name__ == "__main__":
     out_stats_dir = Path(f"{args.out_dir}/stats")
     out_stats_dir.mkdir(parents=True, exist_ok=True)
 
+    # NOTE: mgc order is fixed regardless of sampling rate
     if args.feature_type == "world":
-        # (mgc, lf0, vuv, bap)
-        # NOTE: 現状、mgcの次元数はサンプリング周波数によらず固定
-        stream_sizes = [60, 1, 1, pyworld.get_num_aperiodicities(sample_rate)]
+        if len(scaler.mean_) > 65:
+            # (mgc, lf0, vuv, mcap)
+            stream_sizes = [60, 1, 1, len(scaler.mean_) - 62]
+            # NOTE: pretend codeap as mcap
+            feat_types = ["f0", "contf0", "mcep", "codeap"]
+        else:
+            # (mgc, lf0, vuv, bap)
+            stream_sizes = [60, 1, 1, pyworld.get_num_aperiodicities(sample_rate)]
+            feat_types = ["f0", "contf0", "mcep", "codeap"]
         # NOTE: scaler for F0 is dummy and never used at usfgan training
         assert len(scaler.mean_.reshape(-1)) == sum(stream_sizes)
+
         usfgan_scaler = {
             "mcep": StandardScaler(
                 scaler.mean_[0:60], scaler.var_[0:60], scaler.scale_[0:60]
@@ -226,7 +234,7 @@ if __name__ == "__main__":
 hop_size: {hop_size}
 sample_rate: {sample_rate}
 aux_channels: {aux_channels}
-feat_types: ["f0", "contf0", "mcep", "codeap"]
+feat_types: {feat_types}
 aux_feats: ["mcep", "codeap"]"""
         )
     elif args.feature_type == "melf0":
@@ -235,6 +243,6 @@ aux_feats: ["mcep", "codeap"]"""
 hop_size: {hop_size}
 sample_rate: {sample_rate}
 aux_channels: {aux_channels}
-feat_types: ["f0", "contf0", "logmsp"]
+feat_types: {feat_types}
 aux_feats: ["logmsp"]"""
         )


### PR DESCRIPTION
Just in case if you want to use the similar parametrization approach as in Sinsy. Note that it doesn't make much sense (at least to me) when used with WORLD vocoder, where the aperiodicity is inherently band-wise.