### PR TITLE
Add guide for training DiffSinger with NNSVS's data created by stage 0

### DIFF
--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/README.md
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/README.md
@@ -107,6 +107,8 @@ Please check mos_utt_list.txt for the list of utterance IDs used for our subject
 
 Code: https://github.com/nnsvs/DiffSinger (branch: namine_ritsu)
 
+Firstly, please do make sure to setup a python environment following the DiffSinger's documentation.
+
 In the following guide, we assume NNSVS and DiffSinger repositories are placed at $HOME/nnsvs and $HOME/DiffSinger, respectively.
 
 The basic strategy is to convert NNSVS's data to one of the DiffSinger's supported databases (i.e., Opencpop), so that the DiffSinger's code can be used with minimal changes. Once the conversion is property done, we can just use DiffSinger's codebase.

--- a/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/README.md
+++ b/recipes/namine_ritsu_utagoe_db/icassp2023-24k-world/README.md
@@ -109,14 +109,18 @@ Code: https://github.com/nnsvs/DiffSinger (branch: namine_ritsu)
 
 In the following guide, we assume NNSVS and DiffSinger repositories are placed at $HOME/nnsvs and $HOME/DiffSinger, respectively.
 
-### Convert NNSVS's dataset to DiffSinger's format
+The basic strategy is to convert NNSVS's data to one of the DiffSinger's supported databases (i.e., Opencpop), so that the DiffSinger's code can be used with minimal changes. Once the conversion is property done, we can just use DiffSinger's codebase.
 
-- You first need to run stage 0 for one of the icassp2023-* recipes (e.g., icassp2023-24k-mel-diffsinger-compat). Make sure to have the `data/acoustic` directory.
-- Once the stage 0 is finished, you can convert the NNSVS' data to Opencpop's style by the following command:
+### Convert NNSVS's dataset to Opencpop's format
+
+- You first need to run stage 0 for one of the icassp2023-* recipes (e.g., icassp2023-24k-mel-diffsinger-compat). Please make sure that `data/acoustic` directory is created.
+- After the stage 0 is finished, you can convert the NNSVS' data to Opencpop's style by the following command:
 
 ```
 python $HOME/nnsvs/utils/nnsvs2opencpop.py data/acoustic/ $HOME/DiffSinger/data/raw/ritsu_24k_diffsinger/segments
 ```
+
+Note that we only tested Namine Ritsu's database, but it should be possible to use other databases as long as the same data preparation as in the NNSVS's stage 0 is used.
 
 ### Feature extraction
 


### PR DESCRIPTION
fixes #161

## How to train DiffSinger

Code: https://github.com/nnsvs/DiffSinger (branch: namine_ritsu)

Firstly, please do make sure to setup a python environment following the DiffSinger's documentation.

In the following guide, we assume NNSVS and DiffSinger repositories are placed at $HOME/nnsvs and $HOME/DiffSinger, respectively.

The basic strategy is to convert NNSVS's data to one of the DiffSinger's supported databases (i.e., Opencpop), so that the DiffSinger's code can be used with minimal changes. Once the conversion is property done, we can just use DiffSinger's codebase.

### Convert NNSVS's dataset to Opencpop's format

- You first need to run stage 0 for one of the icassp2023-* recipes (e.g., icassp2023-24k-mel-diffsinger-compat). Please make sure that `data/acoustic` directory is created.
- After the stage 0 is finished, you can convert the NNSVS' data to Opencpop's style by the following command:

```
python $HOME/nnsvs/utils/nnsvs2opencpop.py data/acoustic/ $HOME/DiffSinger/data/raw/ritsu_24k_diffsinger/segments
```

Note that we only tested Namine Ritsu's database, but it should be possible to use other databases as long as the same data preparation as in the NNSVS's stage 0 is used.

### Feature extraction

Please make sure to change the working directory to the DiffSinger directory.

```
cd $HOME/DiffSinger
```

Then, run the following command:

```
PYTHONPATH=. CUDA_VISIBLE_DEVICES=0 python data_gen/tts/bin/binarize.py --config usr/configs/midi/cascade/opencs/aux_rel_ritsu.yaml
```

### Training pitch extarctor

```
PYTHONPATH=. CUDA_VISIBLE_DEVICES=0 python tasks/run.py --config usr/configs/midi/pe_ritsu.yaml --exp_name 0923_ritsu_pe --reset
```

### Training DiffSinger MIDI-B version

There are two configs for training DiffSinger's acoustic model:

- usr/configs/midi/e2e/opencpop/ds100_adj_rel_ritsu_v3_ritsu_pe.yaml
- usr/configs/midi/e2e/opencpop/ds100_adj_rel_ritsu_v4_ritsu_pe.yaml

#### Using the pre-trained vocoder for Namine Ritsu (ds100_adj_rel_ritsu_v4_ritsu_pe.yaml)

NOTE: To train a DiffSinger model used in our experiments, you must need a pre-trained vocoder trained on Namine Ritsu's database. If you want to get a pre-trained model, please contact [@r9y9](https://github.com/r9y9).

```
PYTHONPATH=. CUDA_VISIBLE_DEVICES=0 python tasks/run.py --config usr/configs/midi/e2e/opencpop/ds100_adj_rel_ritsu_v4_ritsu_pe.yaml --exp_name 0923_ds100_adj_rel_ritsu_v4_ritsu_pe --reset
```

#### Using the pre-trained universal vocoder provided by the DiffSinger's authors (ds100_adj_rel_ritsu_v3_ritsu_pe.yaml)

Alternatively, if you are fine with the pre-trained universal vocoder provided by the DiffSinger's authors, you can train the DiffSinger by the following command:

```
PYTHONPATH=. CUDA_VISIBLE_DEVICES=0 python tasks/run.py --config usr/configs/midi/e2e/opencpop/ds100_adj_rel_ritsu_v3_ritsu_pe.yaml --exp_name 0923_ds100_adj_rel_ritsu_v3_ritsu_pe --reset
```

The results get slightly worse in my experience, but it should work fine.

### Synthesizing waveforms

Add ``--infer`` to the training command. e.g.,

```
PYTHONPATH=. CUDA_VISIBLE_DEVICES=0 python tasks/run.py --config usr/configs/midi/e2e/opencpop/ds100_adj_rel_ritsu_v4_ritsu_pe.yaml --exp_name 0923_ds100_adj_rel_ritsu_v4_ritsu_pe --reset --infer
```

Please also check the DiffSinger's documentation for the detailed usage.
