### PR TITLE
Fix MDN-based multi-stream models

### DIFF
--- a/nnsvs/bin/train_acoustic.py
+++ b/nnsvs/bin/train_acoustic.py
@@ -184,6 +184,8 @@ def train_step(
             if prediction_type == PredictionType.MULTISTREAM_HYBRID:
                 if len(pred_out_feats) == 4:
                     pred_mgc, pred_lf0, pred_vuv, pred_bap = pred_out_feats
+                    if isinstance(pred_lf0, tuple):
+                        pred_lf0 = mdn_get_most_probable_sigma_and_mu(*pred_lf0)[1]
                     if isinstance(pred_mgc, tuple):
                         pred_mgc = mdn_get_most_probable_sigma_and_mu(*pred_mgc)[1]
                     if isinstance(pred_bap, tuple):
@@ -193,6 +195,8 @@ def train_step(
                     )
                 elif len(pred_out_feats) == 3:
                     pred_mel, pred_lf0, pred_vuv = pred_out_feats
+                    if isinstance(pred_lf0, tuple):
+                        pred_lf0 = mdn_get_most_probable_sigma_and_mu(*pred_lf0)[1]
                     if isinstance(pred_mel, tuple):
                         pred_mel = mdn_get_most_probable_sigma_and_mu(*pred_mel)[1]
                     pred_out_feats_ = torch.cat([pred_mel, pred_lf0, pred_vuv], dim=-1)

--- a/nnsvs/train_util.py
+++ b/nnsvs/train_util.py
@@ -1726,6 +1726,8 @@ def eval_spss_model(
         # Hybrid
         if prediction_type == PredictionType.MULTISTREAM_HYBRID:
             pred_mgc, pred_lf0, pred_vuv, pred_bap = outs
+            if isinstance(pred_lf0, tuple):
+                pred_lf0 = mdn_get_most_probable_sigma_and_mu(*pred_lf0)[1]
             if isinstance(pred_mgc, tuple):
                 pred_mgc = mdn_get_most_probable_sigma_and_mu(*pred_mgc)[1]
             if isinstance(pred_bap, tuple):
@@ -1944,6 +1946,8 @@ def eval_mel_model(
         # Hybrid
         if prediction_type == PredictionType.MULTISTREAM_HYBRID:
             pred_logmel, pred_lf0, pred_vuv = outs
+            if isinstance(pred_lf0, tuple):
+                pred_lf0 = mdn_get_most_probable_sigma_and_mu(*pred_lf0)[1]
             if isinstance(pred_logmel, tuple):
                 pred_logmel = mdn_get_most_probable_sigma_and_mu(*pred_logmel)[1]
             pred_out_feats = torch.cat([pred_logmel, pred_lf0, pred_vuv], dim=-1)

--- a/tests/test_acoustic_models.py
+++ b/tests/test_acoustic_models.py
@@ -167,8 +167,9 @@ def test_resf0_variance_predictor(num_gaussians):
 
 @pytest.mark.parametrize("reduction_factor", [1, 2])
 @pytest.mark.parametrize("num_gaussians", [1, 2, 4])
+@pytest.mark.parametrize("use_mdn_lf0", [False, True])
 def test_hybrid_multistream_mel_model_vuv_pred_from_mel(
-    reduction_factor, num_gaussians
+    reduction_factor, num_gaussians, use_mdn_lf0
 ):
     params = {
         "in_dim": 300,
@@ -183,6 +184,8 @@ def test_hybrid_multistream_mel_model_vuv_pred_from_mel(
             num_layers=1,
             in_lf0_idx=-1,
             out_lf0_idx=0,
+            use_mdn=use_mdn_lf0,
+            num_gaussians=num_gaussians,
         ),
         # Decoders
         "mel_model": MDN(
@@ -251,8 +254,9 @@ def test_multistream_mel_model(reduction_factor):
 
 @pytest.mark.parametrize("num_gaussians", [1, 2, 4])
 @pytest.mark.parametrize("vuv_model_bap0_conditioning", [False, True])
+@pytest.mark.parametrize("use_mdn_lf0", [False, True])
 def test_npss_mdn_multistream_parametric_model(
-    num_gaussians, vuv_model_bap0_conditioning
+    num_gaussians, vuv_model_bap0_conditioning, use_mdn_lf0
 ):
     params = {
         "in_dim": 300,
@@ -267,7 +271,8 @@ def test_npss_mdn_multistream_parametric_model(
             num_layers=1,
             in_lf0_idx=-1,
             out_lf0_idx=0,
-            use_mdn=False,
+            use_mdn=use_mdn_lf0,
+            num_gaussians=num_gaussians,
         ),
         # Decoders
         "mgc_model": MDN(


### PR DESCRIPTION
- to support MDN-based F0 prediction models
- to support non-MDN models for mgc/bap/mel feature streams
- fix bug that predicted lf0 is used as the input of vuv prediction model during training
- fix bug that sigma is passed to the vuv prediction model instead of mu durning inference


Fixes #171 