### PR TITLE
Expose initial value parameter for autoregressive decoder impl

### DIFF
--- a/nnsvs/acoustic_models/tacotron.py
+++ b/nnsvs/acoustic_models/tacotron.py
@@ -21,6 +21,14 @@ class NonAttentiveDecoder(TacotronNonAttentiveDecoder):
 
     Duration-informed Tacotron :cite:t:`okamoto2019tacotron`.
 
+    .. note::
+
+        if the target features of the decoder is normalized to N(0, 1), consider
+        setting the initial value carefully so that it roughly matches the value of
+        silence. e.g., -4 to -10.
+        ``initial_value=0`` works okay for large databases but I found that -4 or
+        lower worked better for smaller databases such as nit-song070.
+
     Args:
         in_dim (int): Input dimension.
         out_dim (int): Output dimension.
@@ -38,6 +46,7 @@ class NonAttentiveDecoder(TacotronNonAttentiveDecoder):
         postnet_dropout (float): Dropout rate of postnet.
         init_type (str): Initialization type.
         eval_dropout (bool): If True, dropout is applied in evaluation.
+        initial_value (float) : initial value for the autoregressive decoder.
     """
 
     def __init__(
@@ -59,6 +68,7 @@ class NonAttentiveDecoder(TacotronNonAttentiveDecoder):
         init_type="none",
         eval_dropout=True,
         prenet_noise_std=0.0,
+        initial_value=0.0,
     ):
         super().__init__(
             in_dim=in_dim,
@@ -73,6 +83,7 @@ class NonAttentiveDecoder(TacotronNonAttentiveDecoder):
             downsample_by_conv=downsample_by_conv,
             eval_dropout=eval_dropout,
             prenet_noise_std=prenet_noise_std,
+            initial_value=initial_value,
         )
         if postnet_layers > 0:
             self.postnet = TacotronPostnet(
@@ -133,6 +144,7 @@ class BiLSTMNonAttentiveDecoder(BaseModel):
         embed_dim (int): Embedding dimension.
         init_type (str): Initialization type.
         eval_dropout (bool): If True, dropout is applied in evaluation.
+        initial_value=0.0,
     """
 
     def __init__(
@@ -161,6 +173,7 @@ class BiLSTMNonAttentiveDecoder(BaseModel):
         init_type="none",
         eval_dropout=True,
         prenet_noise_std=0.0,
+        initial_value=0.0,
     ):
         super().__init__()
         self.in_dim = in_dim
@@ -230,6 +243,7 @@ class BiLSTMNonAttentiveDecoder(BaseModel):
             downsample_by_conv=downsample_by_conv,
             eval_dropout=eval_dropout,
             prenet_noise_std=prenet_noise_std,
+            initial_value=initial_value,
         )
 
         if postnet_layers > 0:
@@ -320,6 +334,7 @@ class BiLSTMMDNNonAttentiveDecoder(BaseModel):
         embed_dim (int): Embedding dimension.
         init_type (str): Initialization type.
         eval_dropout (bool): If True, dropout is applied in evaluation.
+        initial_value (float) : initial value for the autoregressive decoder.
     """
 
     def __init__(
@@ -346,6 +361,7 @@ class BiLSTMMDNNonAttentiveDecoder(BaseModel):
         init_type="none",
         eval_dropout=True,
         prenet_noise_std=0,
+        initial_value=0.0,
     ):
         super().__init__()
         self.in_dim = in_dim
@@ -417,6 +433,7 @@ class BiLSTMMDNNonAttentiveDecoder(BaseModel):
             sampling_mode=sampling_mode,
             eval_dropout=eval_dropout,
             prenet_noise_std=prenet_noise_std,
+            initial_value=initial_value,
         )
         init_weights(self, init_type)
 

--- a/nnsvs/tacotron/decoder.py
+++ b/nnsvs/tacotron/decoder.py
@@ -105,6 +105,7 @@ class NonAttentiveDecoder(BaseModel):
         attention_conv_channel (int) : number of attention convolution channels
         attention_conv_kernel_size (int) : kernel size of attention convolution
         downsample_by_conv (bool) : if True, downsample by convolution
+        initial_value (float) : initial value for the autoregressive decoder.
     """
 
     def __init__(
@@ -122,12 +123,14 @@ class NonAttentiveDecoder(BaseModel):
         init_type="none",
         eval_dropout=True,
         prenet_noise_std=0.0,
+        initial_value=0.0,
     ):
         super().__init__()
         self.out_dim = out_dim
         self.reduction_factor = reduction_factor
         self.prenet_dropout = prenet_dropout
         self.prenet_noise_std = prenet_noise_std
+        self.initial_value = initial_value
 
         if prenet_layers > 0:
             self.prenet = Prenet(
@@ -210,7 +213,10 @@ class NonAttentiveDecoder(BaseModel):
             h_list.append(self._zero_state(encoder_outs))
             c_list.append(self._zero_state(encoder_outs))
 
-        go_frame = encoder_outs.new_zeros(encoder_outs.size(0), self.out_dim)
+        go_frame = (
+            encoder_outs.new_zeros(encoder_outs.size(0), self.out_dim)
+            + self.initial_value
+        )
         prev_out = go_frame
 
         if not is_inference and self.prenet is not None:
@@ -278,6 +284,7 @@ class MDNNonAttentiveDecoder(BaseModel):
         sampling_mode (str): sampling mode
         init_type (str): initialization type
         eval_dropout (bool): if True, use dropout in evaluation
+        initial_value (float) : initial value for the autoregressive decoder.
     """
 
     def __init__(
@@ -297,6 +304,7 @@ class MDNNonAttentiveDecoder(BaseModel):
         init_type="none",
         eval_dropout=True,
         prenet_noise_std=0.0,
+        initial_value=0.0,
     ):
         super().__init__()
         self.out_dim = out_dim
@@ -306,6 +314,7 @@ class MDNNonAttentiveDecoder(BaseModel):
         self.num_gaussians = num_gaussians
         self.sampling_mode = sampling_mode
         assert sampling_mode in ["mean", "random"]
+        self.initial_value = initial_value
 
         if prenet_layers > 0:
             self.prenet = Prenet(
@@ -386,7 +395,10 @@ class MDNNonAttentiveDecoder(BaseModel):
             h_list.append(self._zero_state(encoder_outs))
             c_list.append(self._zero_state(encoder_outs))
 
-        go_frame = encoder_outs.new_zeros(encoder_outs.size(0), self.out_dim)
+        go_frame = (
+            encoder_outs.new_zeros(encoder_outs.size(0), self.out_dim)
+            + self.initial_value
+        )
         prev_out = go_frame
 
         if not is_inference and self.prenet is not None:

--- a/recipes/_common/conf/jp_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap.yaml
@@ -79,6 +79,7 @@ netG:
     postnet_kernel_size: 5
     postnet_dropout: 0.0
     init_type: "kaiming_normal"
+    initial_value: -7.0
 
   # Aperiodic parameter prediction model
   bap_model:
@@ -105,6 +106,7 @@ netG:
     postnet_kernel_size: 5
     postnet_dropout: 0.0
     init_type: "kaiming_normal"
+    initial_value: -7.0
 
   # V/UV prediction model
   vuv_model:

--- a/recipes/_common/conf/jp_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap_v2.yaml
+++ b/recipes/_common/conf/jp_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_world_multi_ar_mgcf0bap_v2.yaml
@@ -80,6 +80,7 @@ netG:
     postnet_kernel_size: 5
     postnet_dropout: 0.0
     init_type: "kaiming_normal"
+    initial_value: -7.0
 
   # Aperiodic parameter prediction model
   bap_model:
@@ -106,6 +107,7 @@ netG:
     postnet_kernel_size: 5
     postnet_dropout: 0.0
     init_type: "kaiming_normal"
+    initial_value: -7.0
 
   # V/UV prediction model
   vuv_model:

--- a/tests/test_acoustic_models.py
+++ b/tests/test_acoustic_models.py
@@ -460,6 +460,7 @@ def test_tacotron_decoder_mdn(
         "downsample_by_conv": downsample_by_conv,
         "num_gaussians": 8,
         "sampling_mode": sampling_mode,
+        "initial_value": 0.0,
     }
     model = MDNNonAttentiveDecoder(**params)
     assert model.prediction_type() == PredictionType.PROBABILISTIC
@@ -505,6 +506,7 @@ def test_tacotron_decoder(reduction_factor, downsample_by_conv, prenet_layers):
         "zoneout": 0.1,
         "reduction_factor": reduction_factor,
         "downsample_by_conv": downsample_by_conv,
+        "initial_value": 0.0,
     }
     model = NonAttentiveDecoder(**params)
     assert model.prediction_type() == PredictionType.DETERMINISTIC


### PR DESCRIPTION
While my previous experiments all used the initial value 0, which was hardcoded, but I realized that -4 worked better for nit-song070 database. Expose the option and add a note.