### PR TITLE
Deprecate unused option and add one more option to multi-stream models

### DIFF
--- a/nnsvs/acoustic_models/multistream.py
+++ b/nnsvs/acoustic_models/multistream.py
@@ -228,6 +228,7 @@ class NPSSMultistreamParametricModel(BaseModel):
         out_lf0_scale=0.23435173188961034,
         npss_style_conditioning=False,
         vuv_model_bap0_conditioning=False,
+        vuv_model_lf0_conditioning=True,
     ):
         super().__init__()
         self.in_dim = in_dim
@@ -235,6 +236,7 @@ class NPSSMultistreamParametricModel(BaseModel):
         self.stream_sizes = stream_sizes
         self.reduction_factor = reduction_factor
         self.vuv_model_bap0_conditioning = vuv_model_bap0_conditioning
+        self.vuv_model_lf0_conditioning = vuv_model_lf0_conditioning
         assert not npss_style_conditioning, "Not supported"
 
         assert len(stream_sizes) in [4]
@@ -319,14 +321,20 @@ class NPSSMultistreamParametricModel(BaseModel):
                 bap_inp = bap[:, :, 0:1]
             else:
                 bap_inp = bap
-            vuv_inp = torch.cat([x, bap_inp, lf0], dim=-1)
+            if self.vuv_model_lf0_conditioning:
+                vuv_inp = torch.cat([x, bap_inp, lf0], dim=-1)
+            else:
+                vuv_inp = torch.cat([x, bap_inp], dim=-1)
             vuv = self.vuv_model.inference(vuv_inp, lengths)
         else:
             if self.vuv_model_bap0_conditioning:
                 y_bap_inp = y_bap[:, :, 0:1]
             else:
                 y_bap_inp = y_bap
-            vuv_inp = torch.cat([x, y_bap_inp, y_lf0], dim=-1)
+            if self.vuv_model_lf0_conditioning:
+                vuv_inp = torch.cat([x, y_bap_inp, y_lf0], dim=-1)
+            else:
+                vuv_inp = torch.cat([x, y_bap_inp], dim=-1)
             vuv = self.vuv_model(vuv_inp, lengths, y_vuv)
 
         # make a concatenated stream
@@ -407,6 +415,7 @@ class NPSSMDNMultistreamParametricModel(BaseModel):
         out_lf0_mean=5.953093881972361,
         out_lf0_scale=0.23435173188961034,
         vuv_model_bap0_conditioning=False,
+        vuv_model_lf0_conditioning=True,
     ):
         super().__init__()
         self.in_dim = in_dim
@@ -414,6 +423,7 @@ class NPSSMDNMultistreamParametricModel(BaseModel):
         self.stream_sizes = stream_sizes
         self.reduction_factor = reduction_factor
         self.vuv_model_bap0_conditioning = vuv_model_bap0_conditioning
+        self.vuv_model_lf0_conditioning = vuv_model_lf0_conditioning
 
         assert len(stream_sizes) in [4]
 
@@ -504,14 +514,20 @@ class NPSSMDNMultistreamParametricModel(BaseModel):
             if self.vuv_model_bap0_conditioning:
                 bap_cond = bap_cond[:, :, 0:1]
 
-            vuv_inp = torch.cat([x, lf0_cond, bap_cond], dim=-1)
+            if self.vuv_model_lf0_conditioning:
+                vuv_inp = torch.cat([x, lf0_cond, bap_cond], dim=-1)
+            else:
+                vuv_inp = torch.cat([x, bap_cond], dim=-1)
             vuv = self.vuv_model.inference(vuv_inp, lengths)
         else:
             if self.vuv_model_bap0_conditioning:
                 y_bap_cond = y_bap[:, :, 0:1]
             else:
                 y_bap_cond = y_bap
-            vuv_inp = torch.cat([x, y_lf0, y_bap_cond], dim=-1)
+            if self.vuv_model_lf0_conditioning:
+                vuv_inp = torch.cat([x, y_lf0, y_bap_cond], dim=-1)
+            else:
+                vuv_inp = torch.cat([x, y_bap_cond], dim=-1)
             vuv = self.vuv_model(vuv_inp, lengths, y_vuv)
 
         if is_inference:
@@ -739,12 +755,14 @@ class MDNMultistreamSeparateF0MelModel(BaseModel):
         out_lf0_idx=60,
         out_lf0_mean=5.953093881972361,
         out_lf0_scale=0.23435173188961034,
+        vuv_model_lf0_conditioning=True,
     ):
         super().__init__()
         self.in_dim = in_dim
         self.out_dim = out_dim
         self.stream_sizes = stream_sizes
         self.reduction_factor = reduction_factor
+        self.vuv_model_lf0_conditioning = vuv_model_lf0_conditioning
 
         assert len(stream_sizes) in [3]
 
@@ -823,10 +841,16 @@ class MDNMultistreamSeparateF0MelModel(BaseModel):
             else:
                 mel_cond = mel
 
-            vuv_inp = torch.cat([x, lf0_cond, mel_cond], dim=-1)
+            if self.vuv_model_lf0_conditioning:
+                vuv_inp = torch.cat([x, lf0_cond, mel_cond], dim=-1)
+            else:
+                vuv_inp = torch.cat([x, mel_cond], dim=-1)
             vuv = self.vuv_model.inference(vuv_inp, lengths)
         else:
-            vuv_inp = torch.cat([x, y_lf0, y_mel], dim=-1)
+            if self.vuv_model_lf0_conditioning:
+                vuv_inp = torch.cat([x, y_lf0, y_mel], dim=-1)
+            else:
+                vuv_inp = torch.cat([x, y_mel], dim=-1)
             vuv = self.vuv_model(vuv_inp, lengths, y_vuv)
 
         if is_inference:


### PR DESCRIPTION
NOTE:

- `npss_style_conditioning` this option was used before writing NNSVS paper but I found it less benefical
- `vuv_model_lf0_conditioning`: I want to experiment with disabling lf0 conditioning for v/uv prediction models