### PR TITLE
Add recipes for the Opencpop corpus

### DIFF
--- a/recipes/_common/conf/zh_dev_48k_nodyn/prepare_features
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/prepare_features
@@ -1,0 +1,1 @@
+../jp_dev_48k_nodyn/prepare_features

--- a/recipes/_common/conf/zh_dev_48k_nodyn/prepare_static_features
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/prepare_static_features
@@ -1,0 +1,1 @@
+../jp_dev_48k_nodyn/prepare_static_features

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/data/myconfig.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/data/myconfig.yaml
@@ -1,0 +1,36 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 8
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: -1
+# Keep all the data in memory or load files from disk every iteration
+allow_cache: true
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/data/test.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/data/test.yaml
@@ -1,0 +1,36 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 0
+batch_size: 2
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: -1
+# Keep all the data in memory or load files from disk every iteration
+allow_cache: true
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/model/duration_mdn.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/model/duration_mdn.yaml
@@ -1,0 +1,13 @@
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.MDNv2
+  in_dim: 68
+  out_dim: 1
+  hidden_dim: 256
+  dropout: 0.5
+  num_layers: 3
+  num_gaussians: 1
+  init_type: "kaiming_normal"

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/model/duration_vp_mdn.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/model/duration_vp_mdn.yaml
@@ -1,0 +1,15 @@
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.VariancePredictor
+  in_dim: 68
+  out_dim: 1
+  hidden_dim: 256
+  num_layers: 5
+  kernel_size: 5
+  dropout: 0.5
+  use_mdn: true
+  num_gaussians: 4
+  init_type: "kaiming_normal"

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/train/myconfig.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/train/myconfig.yaml
@@ -1,0 +1,42 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: false
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 100
+checkpoint_epoch_interval: 50
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: mse
+
+stream_wise_loss: false
+use_detect_anomaly: false
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/train/test.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/duration/train/test.yaml
@@ -1,0 +1,42 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: false
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 2
+checkpoint_epoch_interval: 2
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: mse
+
+stream_wise_loss: false
+use_detect_anomaly: true
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/data/myconfig.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/data/myconfig.yaml
@@ -1,0 +1,36 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 2
+batch_size: 8
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: -1
+# Keep all the data in memory or load files from disk every iteration
+allow_cache: true
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/data/test.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/data/test.yaml
@@ -1,0 +1,36 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 0
+batch_size: 2
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: -1
+# Keep all the data in memory or load files from disk every iteration
+allow_cache: true
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: false
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/model/timelag_mdn.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/model/timelag_mdn.yaml
@@ -1,0 +1,13 @@
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.MDNv2
+  in_dim: 68
+  out_dim: 1
+  hidden_dim: 32
+  dropout: 0.5
+  num_layers: 3
+  num_gaussians: 1
+  init_type: "kaiming_normal"

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/model/timelag_vp_mdn.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/model/timelag_vp_mdn.yaml
@@ -1,0 +1,15 @@
+stream_sizes: [1]
+has_dynamic_features: [false]
+stream_weights: [1]
+
+netG:
+  _target_: nnsvs.model.VariancePredictor
+  in_dim: 68
+  out_dim: 1
+  hidden_dim: 32
+  num_layers: 3
+  kernel_size: 3
+  dropout: 0.5
+  use_mdn: true
+  num_gaussians: 4
+  init_type: "kaiming_normal"

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/train/myconfig.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/train/myconfig.yaml
@@ -1,0 +1,42 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: false
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 100
+checkpoint_epoch_interval: 50
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: mse
+
+stream_wise_loss: false
+use_detect_anomaly: false
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/train/test.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train/timelag/train/test.yaml
@@ -1,0 +1,42 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: false
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 2
+checkpoint_epoch_interval: 2
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: mse
+
+stream_wise_loss: false
+use_detect_anomaly: true
+
+optim:
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.001
+      betas: [0.9, 0.999]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 20
+      gamma: 0.5
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/melf0_diffusion.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/melf0_diffusion.yaml
@@ -1,0 +1,49 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 8
+batch_size: 0
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: 40000
+# Keep all the data in memory or load files from disk every iteration
+allow_cache: true
+
+sample_rate: 48000
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: true
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null
+
+# NOTE: the following parameters must be carefully set
+# log-F0 and rest parameter indices in the input features
+# it depends on the hed file
+in_lf0_idx: 62
+in_rest_idx: 0
+# The log-F0 index in the output features
+out_lf0_idx: 80
+
+# Use world codec for spectral envelope or not
+use_world_codec: true

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/melf0_diffusion.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/melf0_diffusion.yaml
@@ -1,3 +1,6 @@
+# Config for diffusion-based models with mel-spectrogram features
+# NOTE: larger batch size is preferred for training stability
+
 # training set
 train_no_dev:
   in_dir:

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/world_diffusion.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/world_diffusion.yaml
@@ -1,3 +1,6 @@
+# Config for diffusion-based models with WORLD features
+# NOTE: larger batch size is preferred for training stability
+
 # training set
 train_no_dev:
   in_dir:

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/world_diffusion.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/data/world_diffusion.yaml
@@ -1,0 +1,49 @@
+# training set
+train_no_dev:
+  in_dir:
+  out_dir:
+
+# development set
+dev:
+  in_dir:
+  out_dir:
+
+# data loader
+num_workers: 8
+batch_size: 0
+pin_memory: true
+# Number of maximum frames to be loaded in a single mini-batch
+# If specified, batch sizes are dynamically adjusted based on the number of frames
+# NOTE: `batch_size` will be ignored if ``batch_max_frames`` is specified
+batch_max_frames: 40000
+# Keep all the data in memory or load files from disk every iteration
+allow_cache: true
+
+sample_rate: 48000
+
+# Filter long segments that easily cause OOM error
+filter_long_segments: true
+# If a segment is longer than this value, it will not be used for training
+# 30 [sec] / 0.005 [sec] = 6000 [frames]
+filter_num_frames: 6000
+filter_min_num_frames: 0
+
+# mini-batch sampling
+# If max_time_frames is specified, (max_time_frames) frames are randomly sampled
+# to create a mini-batch. Otherwise, all frames are used.
+# consider setting the value (e.g., 256 or 512) to avoid GPU OOM.
+max_time_frames: -1
+
+in_scaler_path: null
+out_scaler_path: null
+
+# NOTE: the following parameters must be carefully set
+# log-F0 and rest parameter indices in the input features
+# it depends on the hed file
+in_lf0_idx: 62
+in_rest_idx: 0
+# The log-F0 index in the output features
+out_lf0_idx: 60
+
+# Use world codec for spectral envelope or not
+use_world_codec: true

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_melf0_ar_f0_diff_mel.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_melf0_ar_f0_diff_mel.yaml
@@ -1,0 +1,151 @@
+# This is a config file for a diffusion-based NNSVS's multi-stream acoustic model
+# with mel-spectrogram-based acoustic features.
+# Compared to WORLD version, it may provide less buzzy and more natural synthetic
+# speech with a loss of pitch-robustness.
+# NOTE: training is very slow but the trained model can achieve signifincatlly
+# better naturalness compared to NNSVS-WORLD v4.
+# NOTE: consider using larger batch size for training stability and longer training
+# iteration to get better performance. Convergence is slower than the other models.
+# NOTE: It is recommencded to try pre-training if you database does not
+# have enough amount of data (> 1h).
+# NOTE: in_ph_start_idx (start index of current-phoneme context) and
+# in_ph_end_idx (end index of current-phoneme context) are hed-specific parameters
+# and used for *optional* phoneme embedding (with embedding size of `embed_dim`).
+# If you want to use this config with you hed file, there are two options:
+#   1. Set `embed_dim` to -1 to disable phoneme embedding (the easiest way)
+#   2. Find start and end indices of current-phoneme contexts in your hed file
+#      and set them to `in_ph_start_idx` and `in_ph_end_idx` respectively.
+# Using phoneme embedding may improve intelligiblity a little, but it is OK
+# not to use it based on our experiments.
+# Please carefully check hed-specific configurations.
+# (mel, lf0, vuv)
+stream_sizes: [80, 1, 1]
+has_dynamic_features: [false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.acoustic_models.MDNMultistreamSeparateF0MelModel
+  # The number of total input phonetic/musical context features.
+  in_dim: 72 # NOTE: need to be changed for each hed file
+  out_dim: 82
+
+  # Must be set as the same as the above stream_sizes
+  stream_sizes: [80, 1, 1]
+  # This is an imporant parameter to control the modeling capability of
+  # autoregressive models. Don't change this unless if you are sure what you do.
+  # The reduction factor of 4 was chosen empirecally.
+  reduction_factor: 4
+
+  # You MUST set in_rest_idx, in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all.
+  # Please configure your hed file so that in_rest_idx to be zero. i.e.,
+  # put the sil-or-not phonetic context on the first item of your hed file.
+  in_rest_idx: 0 # NOTE: need to be changed for each hed file
+  in_lf0_idx: 62 # NOTE: need to be changed for each hed file
+  out_lf0_idx: 80
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # Flags to control conditioning features for V/UV prediction
+  # If all true, [mel, lf0] are used for V/UV prediction.
+  # IMPORTANT: not optimized yet
+  vuv_model_lf0_conditioning: true
+  vuv_model_mel_conditioning: true
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    # in_dim must be equal to netG.in_dim
+    in_dim: 72 # NOTE: need to be changed for each hed file
+    # out_dim must be equal to the dimension of log-F0
+    out_dim: 1
+    in_ph_start_idx: 1 # NOTE: need to be changed for each hed file
+    in_ph_end_idx: 62 # NOTE: need to be changed for each hed file
+    # Set to -1 to disable phoneme embedding
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    # This must be the same as netG.reduction_factor. Don't change
+    reduction_factor: 4
+    downsample_by_conv: true
+    # This must be the same as netG.in_lf0_idx
+    in_lf0_idx: 62 # NOTE: need to be changed for each hed file
+    # This must be 0. Don't change
+    out_lf0_idx: 0
+    # OK to leave unspecified
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Spectral parameter prediction model
+  mel_model:
+    _target_: nnsvs.diffsinger.GaussianDiffusion
+    in_dim: 73 # (x, lf0) # NOTE: need to be changed for each hed file
+    out_dim: 80
+    # Parameter to convert mean-var normalized data (~ N(0, 1)) to [-1, 1].
+    # may need to adjust in 5 to 10.
+    # assuming that the absolute maximum value of the normalized data is smaller than
+    # `norm_scale` so the data (~ N(0,1); 99.9% are in [-norm_scale, norm_scale]) is
+    # property scaled to [-1, 1]
+    norm_scale: 10
+    # The encoder processes the phonetic/musical contexts into hidden representations
+    encoder:
+       _target_: nnsvs.model.FFConvLSTM
+       # This must be equal to netG.mel_model.in_dim
+       in_dim: 73 # (x, lf0) # NOTE: need to be changed for each hed file
+       in_ph_start_idx: 1 # NOTE: need to be changed for each hed file
+       in_ph_end_idx: 62 # NOTE: need to be changed for each hed file
+       embed_dim: 256
+       ff_hidden_dim: 512
+       conv_hidden_dim: 256
+       lstm_hidden_dim: 128
+       num_lstm_layers: 2
+       bidirectional: true
+       dropout: 0.0
+       out_dim: 256
+    K_step: 100
+    betas: null
+    # Beta scheduler
+    schedule_type: linear
+    scheduler_params:
+      max_beta: 0.06
+    # Denoiser (noise -> output features)
+    denoise_fn:
+      _target_: nnsvs.diffsinger.DiffNet
+      # in_dim must be equal to netG.mel_model.out_dim
+      in_dim: 80
+      encoder_hidden_dim: 256
+      residual_layers: 20
+      residual_channels: 256
+      dilation_cycle_length: 4
+
+  # V/UV prediction model
+  vuv_model:
+    _target_: nnsvs.model.FFConvLSTM
+    in_dim: 153 # (x, mel, lf0) # NOTE: need to be changed for each hed file
+    in_ph_start_idx: 1 # NOTE: need to be changed for each hed file
+    in_ph_end_idx: 62 # NOTE: need to be changed for each hed file
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+    init_type: "kaiming_normal"

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_world_multi_ar_f0_diff_mgcbap.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/model/acoustic_nnsvs_world_multi_ar_f0_diff_mgcbap.yaml
@@ -1,0 +1,189 @@
+# This is a config file for a diffusion-based NNSVS's multi-stream acoustic model
+# with WORLD-based acoustic features.
+# NOTE: training is very slow but the trained model can achieve signifincatlly
+# better naturalness compared to NNSVS-WORLD v4.
+# NOTE: consider using larger batch size for training stability and longer training
+# iteration to get better performance. Convergence is slower than the other models.
+# NOTE: It is recommencded to try pre-training if you database does not
+# have enough amount of data (> 1h).
+# NOTE: in_ph_start_idx (start index of current-phoneme context) and
+# in_ph_end_idx (end index of current-phoneme context) are hed-specific parameters
+# and used for *optional* phoneme embedding (with embedding size of `embed_dim`).
+# If you want to use this config with you hed file, there are two options:
+#   1. Set `embed_dim` to -1 to disable phoneme embedding (the easiest way)
+#   2. Find start and end indices of current-phoneme contexts in your hed file
+#      and set them to `in_ph_start_idx` and `in_ph_end_idx` respectively.
+# Using phoneme embedding may improve intelligiblity a little, but it is OK
+# not to use it based on our experiments.
+# Please carefully check hed-specific configurations.
+
+# (mgc, lf0, vuv, bap)
+stream_sizes: [60, 1, 1, 5]
+has_dynamic_features: [false, false, false, false]
+num_windows: 1
+stream_weights:
+
+netG:
+  _target_: nnsvs.acoustic_models.NPSSMDNMultistreamParametricModel
+  # The number of total input phonetic/musical context features.
+  in_dim: 72 # NOTE: need to be changed for each hed file
+  out_dim: 67
+
+  # Must be set as the same as the above stream_sizes
+  stream_sizes: [60, 1, 1, 5]
+  # This is an imporant parameter to control the modeling capability of
+  # autoregressive models. Don't change this unless if you are sure what you do.
+  # The reduction factor of 4 was chosen empirecally.
+  reduction_factor: 4
+
+  # You MUST set in_rest_idx, in_lf0_idx and out_lf0_idx correctly
+  # otherwise the model does't work at all.
+  # Please configure your hed file so that in_rest_idx to be zero. i.e.,
+  # put the sil-or-not phonetic context on the first item of your hed file.
+  in_rest_idx: 0 # NOTE: need to be changed for each hed file
+  in_lf0_idx: 62 # NOTE: need to be changed for each hed file
+  out_lf0_idx: 60
+  # Please leave the following parameters unspecified if you want to
+  # find the corresponding values automatically from in/out scalers.
+  in_lf0_min: null
+  in_lf0_max: null
+  out_lf0_mean: null
+  out_lf0_scale: null
+
+  # Flags to control conditioning features for V/UV prediction
+  # If all true, [mgc, lf0, bap] are used for V/UV prediction.
+  # IMPORTANT: not optimized yet
+  vuv_model_bap_conditioning: false
+  # if true, only 0-th dim of bap is used
+  vuv_model_bap0_conditioning: false
+  vuv_model_lf0_conditioning: true
+  vuv_model_mgc_conditioning: true
+
+  # A separate model for modeling continuous log-F0
+  lf0_model:
+    _target_: nnsvs.acoustic_models.BiLSTMResF0NonAttentiveDecoder
+    # in_dim must be equal to netG.in_dim
+    in_dim: 72 # NOTE: need to be changed for each hed file
+    # out_dim must be equal to the dimension of log-F0
+    out_dim: 1
+    in_ph_start_idx: 1 # NOTE: need to be changed for each hed file
+    in_ph_end_idx: 62 # NOTE: need to be changed for each hed file
+    # Set to -1 to disable phoneme embedding
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    decoder_layers: 1
+    decoder_hidden_dim: 256
+    prenet_layers: 0
+    prenet_hidden_dim: 16
+    prenet_dropout: 0.5
+    scaled_tanh: true
+    zoneout: 0.0
+    # This must be the same as netG.reduction_factor. Don't change
+    reduction_factor: 4
+    downsample_by_conv: true
+    # This must be the same as netG.in_lf0_idx
+    in_lf0_idx: 62 # NOTE: need to be changed for each hed file
+    # This must be 0. Don't change
+    out_lf0_idx: 0
+    # OK to leave unspecified
+    in_lf0_min: null
+    in_lf0_max: null
+    out_lf0_mean: null
+    out_lf0_scale: null
+
+  # Spectral parameter prediction model
+  mgc_model:
+    _target_: nnsvs.diffsinger.GaussianDiffusion
+    in_dim: 73 # (x, lf0) # NOTE: need to be changed for each hed file
+    out_dim: 60
+    # The encoder processes the phonetic/musical contexts into hidden representations
+    encoder:
+       _target_: nnsvs.model.FFConvLSTM
+       # This must be equal to netG.mgc_model.in_dim
+       in_dim: 73 # (x, lf0) # NOTE: need to be changed for each hed file
+       in_ph_start_idx: 1 # NOTE: need to be changed for each hed file
+       in_ph_end_idx: 62 # NOTE: need to be changed for each hed file
+       embed_dim: 256
+       ff_hidden_dim: 512
+       conv_hidden_dim: 256
+       lstm_hidden_dim: 128
+       num_lstm_layers: 2
+       bidirectional: true
+       dropout: 0.0
+       out_dim: 256
+    K_step: 100
+    betas: null
+    # Beta scheduler
+    schedule_type: linear
+    scheduler_params:
+      max_beta: 0.06
+    # Denoiser (noise -> output features)
+    denoise_fn:
+      _target_: nnsvs.diffsinger.DiffNet
+      # in_dim must be equal to netG.mgc_model.out_dim
+      in_dim: 60
+      encoder_hidden_dim: 256
+      residual_layers: 20
+      residual_channels: 256
+      dilation_cycle_length: 4
+
+  # Aperiodic parameter prediction model
+  bap_model:
+    _target_: nnsvs.diffsinger.GaussianDiffusion
+    in_dim: 73 # (x, lf0) # NOTE: need to be changed for each hed file
+    out_dim: 5
+    # Parameter to convert mean-var normalized data (~ N(0, 1)) to [-1, 1].
+    # may need to adjust in 5 to 10.
+    # assuming that the absolute maximum value of the normalized data is smaller than
+    # `norm_scale` so the data (~ N(0,1); 99.9% are in [-norm_scale, norm_scale]) is
+    # property scaled to [-1, 1]
+    norm_scale: 10
+    # The encoder processes the phonetic/musical contexts into hidden representations
+    encoder:
+       _target_: nnsvs.model.FFConvLSTM
+       # This must be equal to netG.bap_model.in_dim
+       in_dim: 73 # (x, lf0) # NOTE: need to be changed for each hed file
+       in_ph_start_idx: 1 # NOTE: need to be changed for each hed file
+       in_ph_end_idx: 62 # NOTE: need to be changed for each hed file
+       embed_dim: 256
+       ff_hidden_dim: 256
+       conv_hidden_dim: 128
+       lstm_hidden_dim: 64
+       num_lstm_layers: 2
+       bidirectional: true
+       dropout: 0.0
+       out_dim: 128
+    K_step: 100
+    betas: null
+    # Beta scheduler
+    schedule_type: linear
+    scheduler_params:
+      max_beta: 0.06
+    # Denoiser (noise -> output features)
+    denoise_fn:
+      _target_: nnsvs.diffsinger.DiffNet
+      # in_dim must be equal to netG.bap_model.out_dim
+      in_dim: 5
+      encoder_hidden_dim: 128
+      residual_layers: 10
+      residual_channels: 128
+      dilation_cycle_length: 4
+
+  # V/UV prediction model
+  vuv_model:
+    _target_: nnsvs.model.FFConvLSTM
+    in_dim: 133 # (x, lf0, mgc) # NOTE: need to be changed for each hed file
+    in_ph_start_idx: 1 # NOTE: need to be changed for each hed file
+    in_ph_end_idx: 62 # NOTE: need to be changed for each hed file
+    embed_dim: 256
+    ff_hidden_dim: 256
+    conv_hidden_dim: 128
+    lstm_hidden_dim: 64
+    num_lstm_layers: 2
+    bidirectional: true
+    out_dim: 1
+    dropout: 0.1
+    init_type: "kaiming_normal"

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/train/diffusion.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/train/diffusion.yaml
@@ -1,3 +1,6 @@
+# Training config for diffusion-based acoustic models.
+# NOTE: longer training iterations are preferred to improve quality
+
 out_dir: exp
 log_dir: tensorboard/exp
 

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/train/diffusion.yaml
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_acoustic/train/diffusion.yaml
@@ -1,0 +1,59 @@
+out_dir: exp
+log_dir: tensorboard/exp
+
+# Use automatic mixed precision training or not
+# only works on supported GPUs
+use_amp: true
+
+# Use distributed training or not. If true, uses distributed data parallel.
+use_ddp: false
+
+# PWG checkpoint for synthesizing waveforms
+pretrained_vocoder_checkpoint: null
+
+# steps can either be specified by steps or epochs
+max_train_steps: -1
+nepochs: 300
+checkpoint_epoch_interval: 50
+
+# mse (mean squared error; l2 loss) or mae (mean absolute error; l1 loss)
+# NOTE: no effect for MDN models
+feats_criterion: l1
+
+# Weight for pitch regularization loss
+# If > 0.0, add a pitch regularization loss that biases the model to
+# predict closer F0 to the F0 derived from the musical score.
+# This is conceptually same as imposing a prior distribution of the residual F0
+# to be N(0, sigma) (if we use L2 loss)
+# https://arxiv.org/abs/2108.02776
+pitch_reg_weight: 0.0
+
+# decay_size * 0.005 sec. decay to compute pitch reg weights
+pitch_reg_decay_size: 60
+
+max_num_eval_utts: 5
+
+stream_wise_loss: false
+use_detect_anomaly: false
+
+optim:
+  optimizer:
+    name: AdamW
+    params:
+      lr: 0.001
+      betas: [0.9, 0.98]
+      weight_decay: 0.0
+  lr_scheduler:
+    name: StepLR
+    params:
+      step_size: 100
+      gamma: 0.5
+  clip_norm: 10.0
+
+resume:
+  checkpoint:
+  load_optimizer: false
+
+cudnn:
+  benchmark: false
+  deterministic: true

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_parallel_wavegan
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_parallel_wavegan
@@ -1,0 +1,1 @@
+../jp_dev_48k_nodyn/train_parallel_wavegan

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_postfilter
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_postfilter
@@ -1,0 +1,1 @@
+../jp_dev_48k_nodyn/train_postfilter

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_sifigan
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_sifigan
@@ -1,0 +1,1 @@
+../jp_dev_48k_nodyn/train_sifigan

--- a/recipes/_common/conf/zh_dev_48k_nodyn/train_usfgan
+++ b/recipes/_common/conf/zh_dev_48k_nodyn/train_usfgan
@@ -1,0 +1,1 @@
+../jp_dev_48k_nodyn/train_usfgan

--- a/recipes/_common/hed/zh_opencpop.hed
+++ b/recipes/_common/hed/zh_opencpop.hed
@@ -1,0 +1,83 @@
+# This is the latest hed file for development (by r9y9)
+# Note that this hed file is meant to be used for experimental purposes and is subject to change.
+# feature dim:: 72 for acoustic model, 68 for duration/timelag
+# in_rest_idx: 0
+# in_lf0_idx: 62
+
+QS "C-Phone_Muon"     {*-sil+*,*-pau+*,*-AP+*,*-SP+*,*-br+*}
+
+QS "C-Phone_sil"   {*-sil+*}
+QS "C-Phone_pau"   {*-pau+*}
+QS "C-Phone_br"   {*-br+*}
+QS "C-Phone_a"   {*-a+*}
+QS "C-Phone_ai"   {*-ai+*}
+QS "C-Phone_an"   {*-an+*}
+QS "C-Phone_ang"   {*-ang+*}
+QS "C-Phone_ao"   {*-ao+*}
+QS "C-Phone_b"   {*-b+*}
+QS "C-Phone_c"   {*-c+*}
+QS "C-Phone_ch"   {*-ch+*}
+QS "C-Phone_d"   {*-d+*}
+QS "C-Phone_e"   {*-e+*}
+QS "C-Phone_ei"   {*-ei+*}
+QS "C-Phone_en"   {*-en+*}
+QS "C-Phone_eng"   {*-eng+*}
+QS "C-Phone_er"   {*-er+*}
+QS "C-Phone_f"   {*-f+*}
+QS "C-Phone_g"   {*-g+*}
+QS "C-Phone_h"   {*-h+*}
+QS "C-Phone_i"   {*-i+*}
+QS "C-Phone_ia"   {*-ia+*}
+QS "C-Phone_ian"   {*-ian+*}
+QS "C-Phone_iang"   {*-iang+*}
+QS "C-Phone_iao"   {*-iao+*}
+QS "C-Phone_ie"   {*-ie+*}
+QS "C-Phone_in"   {*-in+*}
+QS "C-Phone_ing"   {*-ing+*}
+QS "C-Phone_iong"   {*-iong+*}
+QS "C-Phone_iu"   {*-iu+*}
+QS "C-Phone_j"   {*-j+*}
+QS "C-Phone_k"   {*-k+*}
+QS "C-Phone_l"   {*-l+*}
+QS "C-Phone_m"   {*-m+*}
+QS "C-Phone_n"   {*-n+*}
+QS "C-Phone_o"   {*-o+*}
+QS "C-Phone_ong"   {*-ong+*}
+QS "C-Phone_ou"   {*-ou+*}
+QS "C-Phone_p"   {*-p+*}
+QS "C-Phone_q"   {*-q+*}
+QS "C-Phone_r"   {*-r+*}
+QS "C-Phone_s"   {*-s+*}
+QS "C-Phone_sh"   {*-sh+*}
+QS "C-Phone_t"   {*-t+*}
+QS "C-Phone_u"   {*-u+*}
+QS "C-Phone_ua"   {*-ua+*}
+QS "C-Phone_uai"   {*-uai+*}
+QS "C-Phone_uan"   {*-uan+*}
+QS "C-Phone_uang"   {*-uang+*}
+QS "C-Phone_ui"   {*-ui+*}
+QS "C-Phone_un"   {*-un+*}
+QS "C-Phone_uo"   {*-uo+*}
+QS "C-Phone_v"   {*-v+*}
+QS "C-Phone_van"   {*-van+*}
+QS "C-Phone_ve"   {*-ve+*}
+QS "C-Phone_vn"   {*-vn+*}
+QS "C-Phone_w"   {*-w+*}
+QS "C-Phone_x"   {*-x+*}
+QS "C-Phone_y"   {*-y+*}
+QS "C-Phone_z"   {*-z+*}
+QS "C-Phone_zh"   {*-zh+*}
+
+# absolute pitch (C/L/R)
+CQS "e1" {/E:(\NOTE)]}
+CQS "d1" {/D:(\NOTE)!}
+CQS "f1" {/F:(\NOTE)#}
+
+# phoneme-level positional features (C)
+CQS "p12" {-(\d+)!}
+
+# length of current note (C)
+CQS "e7" {@(\d+)#}
+
+# whether slur or not (C)
+CQS "e26" {|(\d+)]}

--- a/recipes/opencpop/README.md
+++ b/recipes/opencpop/README.md
@@ -1,0 +1,27 @@
+# opencpop
+
+Recipe of the [Opencpop corpus](https://wenet.org.cn/opencpop/).
+
+## How to use
+
+You must first agree to the Opencpop's lincense to download the database.
+Please follow the offical guide: https://wenet.org.cn/opencpop/download/.
+
+After downloading the database, please run the following command to convert the corpus to NNSVS's structure:
+
+```
+./run.sh  --stage 0 --stop-stage 0 --db-root /your/path/to/opencpop/segments
+```
+
+Then, you can run recipes as the same as the other recipes.
+
+e.g.,
+
+Feature extraction
+```
+./run.sh  --stage 1 --stop-stage 1
+```
+
+## Demo samples
+
+https://r9y9.github.io/projects/nnsvs/

--- a/recipes/opencpop/README.md
+++ b/recipes/opencpop/README.md
@@ -5,7 +5,7 @@ Recipe of the [Opencpop corpus](https://wenet.org.cn/opencpop/).
 ## How to use
 
 You must first agree to the Opencpop's lincense to download the database.
-Please follow the offical guide: https://wenet.org.cn/opencpop/download/.
+Please follow the official guide: https://wenet.org.cn/opencpop/download/.
 
 After downloading the database, please run the following command to convert the corpus to NNSVS's structure:
 

--- a/recipes/opencpop/dev-48k-melf0/config.yaml
+++ b/recipes/opencpop/dev-48k-melf0/config.yaml
@@ -1,0 +1,106 @@
+### General settings.
+## The name of singer
+spk: "opencpop"
+
+## exp tag(for managing experiments)
+tag:
+
+## Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: ""
+
+## Output directory
+# All the generated labels, intermediate files, and segmented wav files
+# will be saved in the following directory
+out_dir: "./data"
+
+## HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/zh_opencpop.hed"
+
+# Audio sampling rate
+# CAUTION: Changing sample_rate may affect the dimension number of acoustic features.
+# DO NOT CHANGE this unless you know the relationship between the dim of bap and sample_rate.
+sample_rate: 48000
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: nnsvs_contrib_melf0_48k
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_vp_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_vp_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_nnsvs_melf0_ar_f0_diff_mel
+acoustic_train: diffusion
+acoustic_data: melf0_diffusion
+
+postfilter_model: postfilter_sp
+postfilter_train: sp
+postfilter_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+# Advanced settings for hyperparameter search with Hydra and Optuna.
+# https://hydra.cc/docs/plugins/optuna_sweeper/
+# NOTE: Don't use spaces for each search space configuration.
+# OK: data.batch_size=range(1,16)
+# NG: data.batch_size=range(1, 16)
+# Example 1: data.batch_size=range(1,16) model.netG.hidden_dim=choice(32,64,128)
+# Example 2: train.optim.optimizer.params.lr=interval(0.0001,0.01)
+timelag_hydra_optuna_sweeper_args:
+timelag_hydra_optuna_sweeper_n_trials: 100
+duration_hydra_optuna_sweeper_args:
+duration_hydra_optuna_sweeper_n_trials: 100
+acoustic_hydra_optuna_sweeper_args:
+acoustic_hydra_optuna_sweeper_n_trials: 100
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+# conf/synthesis/synthesis/${synthesis}
+synthesis: melf0_gv_usfgan
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth
+postfilter_eval_checkpoint: latest.pth
+
+###########################################################
+#                VOCODER SETTING                          #
+###########################################################
+
+# NOTE: conf/parallel_wavegan/${vocoder_model}.yaml must exist.
+vocoder_model:
+# Pretrained checkpoint path for the vocoder model
+# NOTE: if you want to try fine-tuning, please specify the path here
+pretrained_vocoder_checkpoint:
+# absolute/relative path to the checkpoint
+# NOTE: the checkpoint is used for synthesis and packing
+# This doesn't have any effect on training
+vocoder_eval_checkpoint:

--- a/recipes/opencpop/dev-48k-melf0/run.sh
+++ b/recipes/opencpop/dev-48k-melf0/run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+function xrun () {
+    set -x
+    $@
+    set +x
+}
+
+script_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
+NNSVS_ROOT=$script_dir/../../../
+NNSVS_COMMON_ROOT=$NNSVS_ROOT/recipes/_common/spsvs
+NO2_ROOT=$NNSVS_ROOT/recipes/_common/no2
+. $NNSVS_ROOT/utils/yaml_parser.sh || exit 1;
+
+eval $(parse_yaml "./config.yaml" "")
+
+train_set="train_no_dev"
+dev_set="dev"
+eval_set="eval"
+datasets=($train_set $dev_set $eval_set)
+testsets=($dev_set $eval_set)
+
+dumpdir=dump
+dump_org_dir=$dumpdir/$spk/org
+dump_norm_dir=$dumpdir/$spk/norm
+
+stage=0
+stop_stage=0
+
+. $NNSVS_ROOT/utils/parse_options.sh || exit 1;
+
+# exp name
+if [ -z ${tag:=} ]; then
+    expname=${spk}
+else
+    expname=${spk}_${tag}
+fi
+expdir=exp/$expname
+
+if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
+    if [ ! -e $db_root ]; then
+	cat<<EOF
+stage -1: Downloading
+
+This recipe does not download the archive of singing voice database automatically to
+provide you the opportunity to read the original license.
+EOF
+    fi
+fi
+
+if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
+    echo "stage 0: Data preparation"
+    python $NNSVS_ROOT/utils/opencpop2nnsvs.py $db_root $out_dir
+fi
+
+# Run the rest of the steps
+# Please check the script file for more details
+. $NNSVS_COMMON_ROOT/run_common_steps_dev.sh

--- a/recipes/opencpop/dev-48k-world/conf
+++ b/recipes/opencpop/dev-48k-world/conf
@@ -1,0 +1,1 @@
+../../_common/conf/zh_dev_48k_nodyn

--- a/recipes/opencpop/dev-48k-world/config.yaml
+++ b/recipes/opencpop/dev-48k-world/config.yaml
@@ -1,0 +1,107 @@
+### General settings.
+## The name of singer
+spk: "opencpop"
+
+## exp tag(for managing experiments)
+tag:
+
+## Directory of Unzipped singing voice database
+# PLEASE CHANGE THE PATH BASED ON YOUR ENVIRONMENT
+db_root: ""
+
+## Output directory
+# All the generated labels, intermediate files, and segmented wav files
+# will be saved in the following directory
+out_dir: "./data"
+
+## HTS-style question used for extracting musical/linguistic context from musicxml files
+question_path: "../../_common/hed/zh_opencpop.hed"
+
+# Audio sampling rate
+# CAUTION: Changing sample_rate may affect the dimension number of acoustic features.
+# DO NOT CHANGE this unless you know the relationship between the dim of bap and sample_rate.
+sample_rate: 48000
+
+###########################################################
+#                FEATURE EXTRACTION SETTING               #
+###########################################################
+
+timelag_features: defaults
+duration_features: defaults
+acoustic_features: nnsvs_contrib_static_only
+
+# Parameter trajectory smoothing
+# Ref: The NAIST Text-to-Speech System for the Blizzard Challenge 2015
+trajectory_smoothing: false
+trajectory_smoothing_cutoff: 50
+
+###########################################################
+#                TRAINING SETTING                         #
+###########################################################
+
+# Models
+# To customize, put your config or change ones in
+# conf/train/{timelag,duration,acoustic}/ and
+# specify the config name below
+# NOTE: *_model: model definition, *_train: general train configs,
+# *_data: data configs (e.g., batch size)
+
+timelag_model: timelag_vp_mdn
+timelag_train: myconfig
+timelag_data: myconfig
+
+duration_model: duration_vp_mdn
+duration_train: myconfig
+duration_data: myconfig
+
+acoustic_model: acoustic_nnsvs_world_multi_ar_f0_diff_mgcbap
+acoustic_train: diffusion
+acoustic_data: world_diffusion
+
+postfilter_model: postfilter_sp
+postfilter_train: sp
+postfilter_data: myconfig
+
+# Pretrained model dir (leave empty to disable)
+pretrained_expdir:
+
+# Advanced settings for hyperparameter search with Hydra and Optuna.
+# https://hydra.cc/docs/plugins/optuna_sweeper/
+# NOTE: Don't use spaces for each search space configuration.
+# OK: data.batch_size=range(1,16)
+# NG: data.batch_size=range(1, 16)
+# Example 1: data.batch_size=range(1,16) model.netG.hidden_dim=choice(32,64,128)
+# Example 2: train.optim.optimizer.params.lr=interval(0.0001,0.01)
+timelag_hydra_optuna_sweeper_args:
+timelag_hydra_optuna_sweeper_n_trials: 100
+duration_hydra_optuna_sweeper_args:
+duration_hydra_optuna_sweeper_n_trials: 100
+acoustic_hydra_optuna_sweeper_args:
+acoustic_hydra_optuna_sweeper_n_trials: 100
+
+###########################################################
+#                SYNTHESIS SETTING                        #
+###########################################################
+# conf/synthesis/synthesis/${synthesis}
+# If you use uSFGAN or SiFi-GAN, please set `world_gv_usfgan`
+synthesis: world_gv
+
+# latest.pth or best.pth
+timelag_eval_checkpoint: latest.pth
+duration_eval_checkpoint: latest.pth
+acoustic_eval_checkpoint: latest.pth
+postfilter_eval_checkpoint: latest.pth
+
+###########################################################
+#                VOCODER SETTING                          #
+###########################################################
+
+# NOTE: conf/parallel_wavegan/${vocoder_model}.yaml must exist.
+vocoder_model:
+# Pretrained checkpoint path for the vocoder model
+# NOTE: if you want to try fine-tuning, please specify the path here
+pretrained_vocoder_checkpoint:
+# absolute/relative path to the checkpoint
+# NOTE: the checkpoint is used for synthesis and packing
+# This doesn't have any effect on training
+vocoder_eval_checkpoint:

--- a/recipes/opencpop/dev-48k-world/run.sh
+++ b/recipes/opencpop/dev-48k-world/run.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Set bash to 'debug' mode, it will exit on :
+# -e 'error', -u 'undefined variable', -o ... 'error in pipeline', -x 'print commands',
+set -e
+set -u
+set -o pipefail
+
+function xrun () {
+    set -x
+    $@
+    set +x
+}
+
+script_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
+NNSVS_ROOT=$script_dir/../../../
+NNSVS_COMMON_ROOT=$NNSVS_ROOT/recipes/_common/spsvs
+NO2_ROOT=$NNSVS_ROOT/recipes/_common/no2
+. $NNSVS_ROOT/utils/yaml_parser.sh || exit 1;
+
+eval $(parse_yaml "./config.yaml" "")
+
+train_set="train_no_dev"
+dev_set="dev"
+eval_set="eval"
+datasets=($train_set $dev_set $eval_set)
+testsets=($dev_set $eval_set)
+
+dumpdir=dump
+dump_org_dir=$dumpdir/$spk/org
+dump_norm_dir=$dumpdir/$spk/norm
+
+stage=0
+stop_stage=0
+
+. $NNSVS_ROOT/utils/parse_options.sh || exit 1;
+
+# exp name
+if [ -z ${tag:=} ]; then
+    expname=${spk}
+else
+    expname=${spk}_${tag}
+fi
+expdir=exp/$expname
+
+if [ ${stage} -le -1 ] && [ ${stop_stage} -ge -1 ]; then
+    if [ ! -e $db_root ]; then
+	cat<<EOF
+stage -1: Downloading
+
+This recipe does not download the archive of singing voice database automatically to
+provide you the opportunity to read the original license.
+EOF
+    fi
+fi
+
+if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
+    echo "stage 0: Data preparation"
+    python $NNSVS_ROOT/utils/opencpop2nnsvs.py $db_root $out_dir
+fi
+
+# Run the rest of the steps
+# Please check the script file for more details
+. $NNSVS_COMMON_ROOT/run_common_steps_dev.sh


### PR DESCRIPTION
Note: Copy-and-pasted from recipes/opencpop/README.md

# opencpop

Recipe of the [Opencpop corpus](https://wenet.org.cn/opencpop/).

## How to use

You must first agree to the Opencpop's lincense to download the database.
Please follow the offical guide: https://wenet.org.cn/opencpop/download/.

After downloading the database, please run the following command to convert the corpus to NNSVS's structure:

```
./run.sh  --stage 0 --stop-stage 0 --db-root /your/path/to/opencpop/segments
```

Then, you can run recipes as the same as the other recipes.

e.g.,

Feature extraction
```
./run.sh  --stage 1 --stop-stage 1
```

## Demo samples

https://r9y9.github.io/projects/nnsvs/


fixes #105 

See also https://github.com/nnsvs/nnsvs/pull/175 for how to train diffusion-based models.
